### PR TITLE
Fix binary too large (fix option to compile without debug logging)

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -75,7 +75,7 @@ CH32V00x_EVT.menu.opt.o0std.build.flags.optimize=-O0
 
 # Debug information
 CH32V00x_EVT.menu.dbg.none=None
-CH32V00x_EVT.menu.dbg.none.build.flags.debug= 
+CH32V00x_EVT.menu.dbg.none.build.flags.debug=-DNDEBUG
 CH32V00x_EVT.menu.dbg.enable_sym=Symbols Enabled (-g)
 CH32V00x_EVT.menu.dbg.enable_sym.build.flags.debug=-g -DNDEBUG
 CH32V00x_EVT.menu.dbg.enable_log=Core logs Enabled
@@ -159,7 +159,7 @@ CH32X035_EVT.menu.opt.o0std.build.flags.optimize=-O0
 
 # Debug information
 CH32X035_EVT.menu.dbg.none=None
-CH32X035_EVT.menu.dbg.none.build.flags.debug= 
+CH32X035_EVT.menu.dbg.none.build.flags.debug=-DNDEBUG
 CH32X035_EVT.menu.dbg.enable_sym=Symbols Enabled (-g)
 CH32X035_EVT.menu.dbg.enable_sym.build.flags.debug=-g -DNDEBUG
 CH32X035_EVT.menu.dbg.enable_log=Core logs Enabled
@@ -243,7 +243,7 @@ CH32V10x_EVT.menu.opt.o0std.build.flags.optimize=-O0
 
 # Debug information
 CH32V10x_EVT.menu.dbg.none=None
-CH32V10x_EVT.menu.dbg.none.build.flags.debug= 
+CH32V10x_EVT.menu.dbg.none.build.flags.debug=-DNDEBUG
 CH32V10x_EVT.menu.dbg.enable_sym=Symbols Enabled (-g)
 CH32V10x_EVT.menu.dbg.enable_sym.build.flags.debug=-g -DNDEBUG
 CH32V10x_EVT.menu.dbg.enable_log=Core logs Enabled
@@ -366,7 +366,7 @@ CH32V20x_EVT.menu.opt.o0std.build.flags.optimize=-O0
 
 # Debug information
 CH32V20x_EVT.menu.dbg.none=None
-CH32V20x_EVT.menu.dbg.none.build.flags.debug= 
+CH32V20x_EVT.menu.dbg.none.build.flags.debug=-DNDEBUG
 CH32V20x_EVT.menu.dbg.enable_sym=Symbols Enabled (-g)
 CH32V20x_EVT.menu.dbg.enable_sym.build.flags.debug=-g -DNDEBUG
 CH32V20x_EVT.menu.dbg.enable_log=Core logs Enabled
@@ -451,7 +451,7 @@ CH32V30x_EVT.menu.opt.o0std.build.flags.optimize=-O0
 
 # Debug information
 CH32V30x_EVT.menu.dbg.none=None
-CH32V30x_EVT.menu.dbg.none.build.flags.debug= 
+CH32V30x_EVT.menu.dbg.none.build.flags.debug=-DNDEBUG
 CH32V30x_EVT.menu.dbg.enable_sym=Symbols Enabled (-g)
 CH32V30x_EVT.menu.dbg.enable_sym.build.flags.debug=-g -DNDEBUG
 CH32V30x_EVT.menu.dbg.enable_log=Core logs Enabled


### PR DESCRIPTION
Binary would be too large, even when selecting optimize smallest with LTO. Cause: Flag NDEBUG was not set.  Fix compiling without debug logging