### PR TITLE
Add clock option for CH32V003

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -2,6 +2,8 @@
 
 menu.pnum=Board Select
 
+menu.clock=Clock Select
+
 menu.xserial=U(S)ART support
 menu.usb=USB support (if available)
 menu.xusb=USB speed (if available)
@@ -48,6 +50,20 @@ CH32V00x_EVT.menu.upload_method.swdMethod.upload.protocol=
 CH32V00x_EVT.menu.upload_method.swdMethod.upload.options=
 CH32V00x_EVT.menu.upload_method.swdMethod.upload.tool=WCH_linkE
 
+
+# Clock Select
+CH32V00x_EVT.menu.clock.48MHz_HSI=48MHz Internal
+CH32V00x_EVT.menu.clock.48MHz_HSI.build.flags.clock=-DSYSCLK_FREQ_48MHz_HSI=48000000
+CH32V00x_EVT.menu.clock.24MHz_HSI=24MHz Internal
+CH32V00x_EVT.menu.clock.24MHz_HSI.build.flags.clock=-DSYSCLK_FREQ_24MHz_HSI=24000000
+CH32V00x_EVT.menu.clock.8MHz_HSI=8MHz Internal
+CH32V00x_EVT.menu.clock.8MHz_HSI.build.flags.clock=-DSYSCLK_FREQ_8MHz_HSI=8000000
+CH32V00x_EVT.menu.clock.48MHz_HSE=48MHz External
+CH32V00x_EVT.menu.clock.48MHz_HSE.build.flags.clock=-DSYSCLK_FREQ_48MHz_HSE=48000000
+CH32V00x_EVT.menu.clock.24MHz_HSE=24MHz External
+CH32V00x_EVT.menu.clock.24MHz_HSE.build.flags.clock=-DSYSCLK_FREQ_24MHz_HSE=24000000
+CH32V00x_EVT.menu.clock.8MHz_HSE=8MHz External
+CH32V00x_EVT.menu.clock.8MHz_HSE.build.flags.clock=-DSYSCLK_FREQ_8MHz_HSE=8000000
 
 
 # Optimizations

--- a/platform.txt
+++ b/platform.txt
@@ -32,15 +32,15 @@ compiler.objdump.cmd=riscv-none-embed-objdump
 
 compiler.libraries.ldflags=
 
-#"@{build.opt.path}" {build.flags.optimize}  {compiler.warning_flags} {build.flags.debug} -MP -MF
+#"@{build.opt.path}" {build.flags.clock} {build.flags.optimize}  {compiler.warning_flags} {build.flags.debug} -MP -MF
 
 compiler.extra_flags=-march={build.march} -mabi={build.mabi} -msmall-data-limit=8 -msave-restore -fmessage-length=0 -fsigned-char -ffunction-sections -fdata-sections -fno-common 
 
 compiler.S.flags={compiler.extra_flags} -x assembler-with-cpp "-I{build.system.path}/{build.series}/SRC/Startup/" "-I{build.core.path}/ch32/"
 
-compiler.c.flags={compiler.extra_flags} -c {build.flags.optimize} {build.flags.debug} {compiler.warning_flags} -std=gnu99 -MMD {compiler.ch.extra_include}
+compiler.c.flags={compiler.extra_flags} -c {build.flags.clock} {build.flags.optimize} {build.flags.debug} {compiler.warning_flags} -std=gnu99 -MMD {compiler.ch.extra_include}
 
-compiler.cpp.flags={compiler.extra_flags} -c {build.flags.optimize} {build.flags.debug} {compiler.warning_flags} -std={compiler.cpp.std}  -fno-threadsafe-statics  -fno-rtti -fno-exceptions -fno-use-cxa-atexit -MMD {compiler.ch.extra_include} -fpermissive
+compiler.cpp.flags={compiler.extra_flags} -c {build.flags.clock} {build.flags.optimize} {build.flags.debug} {compiler.warning_flags} -std={compiler.cpp.std}  -fno-threadsafe-statics  -fno-rtti -fno-exceptions -fno-use-cxa-atexit -MMD {compiler.ch.extra_include} -fpermissive
 
 compiler.ar.flags=rcs
 
@@ -99,6 +99,7 @@ build.enable_virtio=
 build.peripheral_pins=
 build.startup_file=
 build.flags.fp=
+build.flags.clock=
 build.flags.optimize=
 build.flags.debug=
 build.flags.ldspecs=

--- a/system/CH32V00x/USER/system_ch32v00x.c
+++ b/system/CH32V00x/USER/system_ch32v00x.c
@@ -17,12 +17,13 @@
 * If none of the define below is enabled, the HSI is used as System clock source. 
 */
 
+//Do it in menu selection in Arduino
 //#define SYSCLK_FREQ_8MHz_HSI    8000000
 //#define SYSCLK_FREQ_24MHZ_HSI   HSI_VALUE
 //#define SYSCLK_FREQ_48MHZ_HSI   48000000
 //#define SYSCLK_FREQ_8MHz_HSE    8000000
 //#define SYSCLK_FREQ_24MHz_HSE   HSE_VALUE
-#define SYSCLK_FREQ_48MHz_HSE   48000000
+//#define SYSCLK_FREQ_48MHz_HSE   48000000
 
 /* Clock Definitions */
 #ifdef SYSCLK_FREQ_8MHz_HSI

--- a/system/CH32V00x/USER/system_ch32v00x.c
+++ b/system/CH32V00x/USER/system_ch32v00x.c
@@ -19,8 +19,8 @@
 
 //Do it in menu selection in Arduino
 //#define SYSCLK_FREQ_8MHz_HSI    8000000
-//#define SYSCLK_FREQ_24MHZ_HSI   HSI_VALUE
-//#define SYSCLK_FREQ_48MHZ_HSI   48000000
+//#define SYSCLK_FREQ_24MHz_HSI   HSI_VALUE
+//#define SYSCLK_FREQ_48MHz_HSI   48000000
 //#define SYSCLK_FREQ_8MHz_HSE    8000000
 //#define SYSCLK_FREQ_24MHz_HSE   HSE_VALUE
 //#define SYSCLK_FREQ_48MHz_HSE   48000000
@@ -28,10 +28,10 @@
 /* Clock Definitions */
 #ifdef SYSCLK_FREQ_8MHz_HSI
   uint32_t SystemCoreClock         = SYSCLK_FREQ_8MHz_HSI;          /* System Clock Frequency (Core Clock) */
-#elif defined SYSCLK_FREQ_24MHZ_HSI
-  uint32_t SystemCoreClock         = SYSCLK_FREQ_24MHZ_HSI;        /* System Clock Frequency (Core Clock) */
-#elif defined SYSCLK_FREQ_48MHZ_HSI
-  uint32_t SystemCoreClock         = SYSCLK_FREQ_48MHZ_HSI;        /* System Clock Frequency (Core Clock) */
+#elif defined SYSCLK_FREQ_24MHz_HSI
+  uint32_t SystemCoreClock         = SYSCLK_FREQ_24MHz_HSI;        /* System Clock Frequency (Core Clock) */
+#elif defined SYSCLK_FREQ_48MHz_HSI
+  uint32_t SystemCoreClock         = SYSCLK_FREQ_48MHz_HSI;        /* System Clock Frequency (Core Clock) */
 #elif defined SYSCLK_FREQ_8MHz_HSE
   uint32_t SystemCoreClock         = SYSCLK_FREQ_8MHz_HSE;         /* System Clock Frequency (Core Clock) */
 #elif defined SYSCLK_FREQ_24MHz_HSE
@@ -50,10 +50,10 @@ static void SetSysClock(void);
 
 #ifdef SYSCLK_FREQ_8MHz_HSI
   static void SetSysClockTo_8MHz_HSI(void);
-#elif defined SYSCLK_FREQ_24MHZ_HSI
-  static void SetSysClockTo_24MHZ_HSI(void);
-#elif defined SYSCLK_FREQ_48MHZ_HSI
-  static void SetSysClockTo_48MHZ_HSI(void);
+#elif defined SYSCLK_FREQ_24MHz_HSI
+  static void SetSysClockTo_24MHz_HSI(void);
+#elif defined SYSCLK_FREQ_48MHz_HSI
+  static void SetSysClockTo_48MHz_HSI(void);
 #elif defined SYSCLK_FREQ_8MHz_HSE
   static void SetSysClockTo_8MHz_HSE(void);
 #elif defined SYSCLK_FREQ_24MHz_HSE
@@ -145,10 +145,10 @@ static void SetSysClock(void)
 {
 #ifdef SYSCLK_FREQ_8MHz_HSI
     SetSysClockTo_8MHz_HSI();
-#elif defined SYSCLK_FREQ_24MHZ_HSI
-    SetSysClockTo_24MHZ_HSI();
-#elif defined SYSCLK_FREQ_48MHZ_HSI
-    SetSysClockTo_48MHZ_HSI();
+#elif defined SYSCLK_FREQ_24MHz_HSI
+    SetSysClockTo_24MHz_HSI();
+#elif defined SYSCLK_FREQ_48MHz_HSI
+    SetSysClockTo_48MHz_HSI();
 #elif defined SYSCLK_FREQ_8MHz_HSE
     SetSysClockTo_8MHz_HSE();
 #elif defined SYSCLK_FREQ_24MHz_HSE
@@ -182,16 +182,16 @@ static void SetSysClockTo_8MHz_HSI(void)
     RCC->CFGR0 |= (uint32_t)RCC_HPRE_DIV3;
 }
 
-#elif defined SYSCLK_FREQ_24MHZ_HSI
+#elif defined SYSCLK_FREQ_24MHz_HSI
 
 /*********************************************************************
- * @fn      SetSysClockTo_24MHZ_HSI
+ * @fn      SetSysClockTo_24MHz_HSI
  *
  * @brief   Sets System clock frequency to 24MHz and configure HCLK, PCLK2 and PCLK1 prescalers.
  *
  * @return  none
  */
-static void SetSysClockTo_24MHZ_HSI(void)
+static void SetSysClockTo_24MHz_HSI(void)
 {
     /* Flash 0 wait state */
     FLASH->ACTLR &= (uint32_t)((uint32_t)~FLASH_ACTLR_LATENCY);
@@ -202,16 +202,16 @@ static void SetSysClockTo_24MHZ_HSI(void)
 }
 
 
-#elif defined SYSCLK_FREQ_48MHZ_HSI
+#elif defined SYSCLK_FREQ_48MHz_HSI
 
 /*********************************************************************
- * @fn      SetSysClockTo_48MHZ_HSI
+ * @fn      SetSysClockTo_48MHz_HSI
  *
  * @brief   Sets System clock frequency to 48MHz and configure HCLK, PCLK2 and PCLK1 prescalers.
  *
  * @return  none
  */
-static void SetSysClockTo_48MHZ_HSI(void)
+static void SetSysClockTo_48MHz_HSI(void)
 {
     /* Flash 0 wait state */
     FLASH->ACTLR &= (uint32_t)((uint32_t)~FLASH_ACTLR_LATENCY);


### PR DESCRIPTION
I tried the Arduino Repo on a customized board and the systick was 50% speed while the UART run in correct speed. After some troubleshooting I realized the clock was set to external 48M, which fails and return to backup internal clock.

This PR allow user to choose clock source. That is useful for projects without external oscillator.  