### PR TITLE
Add debug feature

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -23,6 +23,7 @@ CH32V00x_EVT.build.board=CH32V00x_EVT
 CH32V00x_EVT.upload.maximum_size=0
 CH32V00x_EVT.upload.maximum_data_size=0
 CH32V00x_EVT.build.variant_h=variant_{build.board}.h
+CH32V00x_EVT.debug.tool=gdb-WCH_LinkE
 
 
 #CH32V003F4 EVT Board

--- a/platform.txt
+++ b/platform.txt
@@ -170,3 +170,17 @@ tools.WCH_linkE.upload.pattern="{path}{cmd}" -f "{upload.config}" -c init -c hal
 
 #tools.WCH_linkE.upload.pattern="{path}{cmd}" -f {upload.config} -c init -c halt -c "program {{build.path}/{build.project_name}.elf}; verify_image {{build.path}/{build.project_name}.elf}; wlink_reset_resume;  exit;"
 
+
+# Debugger configuration (general options)
+# ----------------------------------------
+# EXPERIMENTAL feature:
+#  - this is alpha and may be subject to change without notice
+debug.executable={build.path}/{build.project_name}.elf
+debug.toolchain=gcc
+debug.toolchain.prefix=riscv-none-embed
+debug.toolchain.path={compiler.path}
+
+debug.server=openocd
+debug.server.openocd.path={runtime.tools.openocd-1.0.0.path}/bin/openocd
+debug.server.openocd.scripts_dir={debug.toolchain.path}/scripts
+debug.server.openocd.script={runtime.tools.openocd.path}/bin/wch-riscv.cfg


### PR DESCRIPTION
The package contains everything Debugging need. GDB, OPENOCD. They are all there. Just a text edit will enable debugging capability.

In Arduino IDE 2, just set debug symbol enabled (-g) in menu and enjoy debugging!