### PR TITLE
Implement Serial.available() function

### DIFF
--- a/cores/arduino/HardwareSerial.cpp
+++ b/cores/arduino/HardwareSerial.cpp
@@ -147,7 +147,7 @@ void HardwareSerial::end()
 
 int HardwareSerial::available(void)
 {
-  return -1;
+  return !serial_rx_active(&_serial);
 }
 
 int HardwareSerial::peek(void)


### PR DESCRIPTION
-1 means if(Serial.available()) is always true.
Returns reception status.