### PR TITLE
Fixed compilation error in X035

### DIFF
--- a/cores/arduino/HardwareTimer.cpp
+++ b/cores/arduino/HardwareTimer.cpp
@@ -70,7 +70,12 @@ HardwareTimer::HardwareTimer(TIM_TypeDef *instance)
 #endif
 
 #ifdef TIM2_BASE
-  NVIC_EnableIRQ(TIM2_IRQn);
+  #ifdef TIM2_IRQn
+    NVIC_EnableIRQ(TIM2_IRQn);
+  #else
+    NVIC_EnableIRQ(TIM2_UP_IRQn);
+    NVIC_EnableIRQ(TIM2_CC_IRQn);
+  #endif
 #endif
 
 #ifdef TIM3_BASE

--- a/cores/arduino/ch32/timer.c
+++ b/cores/arduino/ch32/timer.c
@@ -259,7 +259,11 @@ IRQn_Type getTimerUpIrq(TIM_TypeDef *tim)
 #endif
 #if defined(TIM2_BASE)
       case (uint32_t)TIM2_BASE:
+#if defined(TIM2_IRQn)
         IRQn = TIM2_IRQn;
+#else
+        IRQn = TIM2_UP_IRQn;
+#endif
         break;
 #endif
 #if defined(TIM3_BASE)
@@ -329,7 +333,11 @@ IRQn_Type getTimerCCIrq(TIM_TypeDef *tim)
 #endif
 #if defined(TIM2_BASE)
       case (uint32_t)TIM2_BASE:
+#if defined(TIM2_IRQn)
         IRQn = TIM2_IRQn;
+#else
+        IRQn = TIM2_CC_IRQn;
+#endif
         break;
 #endif
 #if defined(TIM3_BASE)


### PR DESCRIPTION
# Fixed compilation error in X035

```
typedef enum IRQn
{
    TIM1_BRK_IRQn = 34,        /* TIM1 Break Interrupt                                 */
    TIM1_UP_IRQn = 35,         /* TIM1 Update Interrupt                                */
    TIM1_TRG_COM_IRQn = 36,    /* TIM1 Trigger and Commutation Interrupt               */
    TIM1_CC_IRQn = 37,         /* TIM1 Capture Compare Interrupt                       */
    TIM2_UP_IRQn = 38,         /* TIM2 Update Interrupt                                */
    TIM2_CC_IRQn = 51,         /* TIM2 Capture Compare Interrupt                       */
    TIM2_TRG_COM_IRQn = 52,    /* TIM2 Trigger and Commutation Interrupt               */
    TIM2_BRK_IRQn = 53,        /* TIM2 Break Interrupt                                 */
    TIM3_IRQn = 54,            /* TIM3 global Interrupt                                */
} IRQn_Type;
```

excerpt. ( https://github.com/openwch/arduino_core_ch32/blob/main/system/CH32X035/SRC/Peripheral/inc/ch32x035.h#L32 )
X035 does not have TIM2_IRQn.
Register CC and UP in the same way as TIM1.