### PR TITLE
I2C slave and scanning

### DIFF
--- a/libraries/Wire/examples/i2cMinimalSlave/i2cMinimalSlave.ino
+++ b/libraries/Wire/examples/i2cMinimalSlave/i2cMinimalSlave.ino
@@ -1,0 +1,57 @@
+/*
+  I2C Minimal Slave - CH32 I2C Slave example
+
+  Show the minimal code required to implement an I2C slave device with these features:
+     - handle I2C scanning (i.e. acknowledge data-less transaction)
+     - handle receiving data
+     - return data requested by master
+     - blink LED on PA2 according transfered value
+  
+  Compiled for CH32V003J4M6 (SOP8) using Arduino IDE v2.3.2, CH32 core v1.0.4. 
+  Optimize: Smallest (-Os default), Debug symbols: none, no UART: //#define UART_MODULE_ENABLED
+  Note - enable I2C slave functionality in /libraries/Wire/src/utility/twi.h
+    #define OPT_I2C_SLAVE 1
+
+  Using those options this sketch uses 9424 bytes (57%) of program storage space. Maximum is 16384 bytes.
+  Global variables use 580 bytes (28%) of dynamic memory, leaving 1468 bytes for local variables. Maximum is 2048 bytes.
+*/
+
+#include <Wire.h>
+#define MY_I2C_ADDRESS 0x33
+ 
+#undef LED_BUILTIN
+#define LED_BUILTIN PA2
+uint32_t _nBlinkSpeed=500;
+
+void ReceiveEvent(int nNumBytes) {
+  // receive value is stored to set the speed of blinking
+  _nBlinkSpeed=0;
+  while(nNumBytes>0)
+  {
+    _nBlinkSpeed<<=8;
+    _nBlinkSpeed|=Wire.read();
+    nNumBytes--;
+  }
+}
+
+void RequestEvent() {
+  // returned 32-bit value is the current speed of blinking
+  Wire.write((const uint8_t *)&_nBlinkSpeed, sizeof(_nBlinkSpeed));;
+}
+
+void setup() {
+  pinMode(LED_BUILTIN, OUTPUT);  // Initialize digital pin LED_BUILTIN as an output.
+  Wire.begin(MY_I2C_ADDRESS);
+  // Note: enable I2C slave functionality in /libraries/Wire/src/utility/twi.h to prevent error message for next two lines
+  Wire.onReceive(ReceiveEvent);
+  Wire.onRequest(RequestEvent);
+}
+
+void loop() {
+  static uint32_t uStart=millis();
+  if(millis()-uStart > _nBlinkSpeed)
+  { // blink the LED by reversing its state
+    digitalWrite(LED_BUILTIN, !digitalRead(LED_BUILTIN));
+    uStart=millis();
+  }
+}

--- a/libraries/Wire/examples/i2c_scanner/README.md
+++ b/libraries/Wire/examples/i2c_scanner/README.md
@@ -1,0 +1,12 @@
+# I2C Scanner
+Original I2C Scanner example by Nick Gammon
+I2C Scanner - Written by Nick Gammon - Date: 20th April 2011 [source](http://arduino-info.wikispaces.com/LCD-Blue-I2C).
+
+Demonstrates CH32 Support for I2C scanning using Wire.endTransmission() without sending data. 
+To enable scanning these changes are required in libraries/Wire/src/utility/twi.c : 
+- timeout on an addresses should release the bus
+- allow only sending the address (without actual data)
+- smaller timeout: I2C_TIMEOUT_TICK 25 (was 100ms)
+
+Note: Currently there's no support for [Wire.setWireTimeout(timeout, reset_on_timeout)](https://www.arduino.cc/reference/en/language/functions/communication/wire/setwiretimeout/).
+Inspiration from [i2c_scanner](https://github.com/mockthebear/easy-ch32v003/tree/main/examples/i2c_scanner) by @mockthebear.

--- a/libraries/Wire/examples/i2c_scanner/i2c_scanner.ino
+++ b/libraries/Wire/examples/i2c_scanner/i2c_scanner.ino
@@ -1,0 +1,60 @@
+
+// I2C Scanner
+// Written by Nick Gammon
+// Date: 20th April 2011
+
+// source: http://arduino-info.wikispaces.com/LCD-Blue-I2C
+
+// MMOLE: CH32 Support I2C scanning using Wire.endTransmission() without sending data
+// CH32 changes required in libraries/Wire/src/utility/twi.c
+//  - timeout on an addresses should release the bus
+//  - allow only sending the address (without actual data)
+//  - smaller timeout: I2C_TIMEOUT_TICK 25 (was 100ms)
+// Note: Currently there's no support for Wire.setWireTimeout(timeout, reset_on_timeout)
+// https://www.arduino.cc/reference/en/language/functions/communication/wire/setwiretimeout/
+// Inspiration from https://github.com/mockthebear/easy-ch32v003/tree/main/examples/i2c_scanner
+
+
+
+#include <Wire.h>
+
+void setup() {
+  Serial.begin (115200);
+
+  // Leonardo: wait for serial port to connect
+  while (!Serial) 
+    {
+    }
+
+  Serial.println ();
+  Serial.println ("I2C scanner. Scanning ...");
+  
+  Wire.begin();
+  while(true)
+  {
+
+  byte count = 0;
+  for (byte i = 8; i < 120; i++)
+  {
+    Wire.beginTransmission (i);
+    if (Wire.endTransmission () == 0)
+      {
+      Serial.print ("Found address: ");
+      Serial.print (i, DEC);
+      Serial.print (" (0x");
+      Serial.print (i, HEX);
+      Serial.println (")");
+      count++;
+      delay (1);  // maybe unneeded?
+      } // end of good response
+  } // end of for loop
+  Serial.println ("Done.");
+  Serial.print ("Found ");
+  Serial.print (count, DEC);
+  Serial.println (" device(s).");
+  delay(1000);
+  Serial.println ("Scanning again...");
+  }
+}  // end of setup
+
+void loop() {}

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -93,10 +93,13 @@ void TwoWire::begin(uint8_t address, bool generalCall, bool NoStretchMode)
 
   if (_i2c.isMaster == 0) 
   {
+#if OPT_I2C_SLAVE
+	// MMOLE: these four lines were all commented
     // i2c_attachSlaveTxEvent(&_i2c, reinterpret_cast<void(*)(i2c_t*)>(&TwoWire::onRequestService));
     // i2c_attachSlaveRxEvent(&_i2c, reinterpret_cast<void(*)(i2c_t*, uint8_t*, int)>(&TwoWire::onReceiveService));
-    // i2c_attachSlaveTxEvent(&_i2c, onRequestService);
-    // i2c_attachSlaveRxEvent(&_i2c, onReceiveService); 
+    i2c_attachSlaveTxEvent(&_i2c, onRequestService);
+    i2c_attachSlaveRxEvent(&_i2c, onReceiveService); 
+#endif
   }
 }
 
@@ -277,11 +280,13 @@ size_t TwoWire::write(uint8_t data)
       txDataSize++;
     }
   } else {
+#if OPT_I2C_SLAVE
     // in slave send mode
     // reply to master
     if (i2c_slave_write(&_i2c, &data, 1) != I2C_OK) {
       ret = 0;
     }
+#endif // #if OPT_I2C_SLAVE
   }
   return ret;
 }
@@ -309,11 +314,13 @@ size_t TwoWire::write(const uint8_t *data, size_t quantity)
       txDataSize += quantity;
     }
   } else {
+#if OPT_I2C_SLAVE
     // in slave send mode
     // reply to master
     if (i2c_slave_write(&_i2c, (uint8_t *)data, quantity) != I2C_OK) {
       ret = 0;
     }
+  #endif // #if OPT_I2C_SLAVE
   }
   return ret;
 }
@@ -372,6 +379,7 @@ void TwoWire::flush(void)
 
 
 // behind the scenes function that is called when data is received
+#if OPT_I2C_SLAVE
 void TwoWire::onReceiveService(i2c_t *obj)
 {
   uint8_t *inBytes = (uint8_t *) obj->i2cTxRxBuffer;
@@ -413,7 +421,9 @@ void TwoWire::onRequestService(i2c_t *obj)
     TW->user_onRequest();
   }
 }
+#endif // #if OPT_I2C_SLAVE
 
+#if OPT_I2C_SLAVE
 // sets function called on slave write
 void TwoWire::onReceive(cb_function_receive_t function)
 {
@@ -425,6 +435,7 @@ void TwoWire::onRequest(cb_function_request_t function)
 {
   user_onRequest = function;
 }
+#endif // #if OPT_I2C_SLAVE
 
 
 

--- a/libraries/Wire/src/utility/twi.c
+++ b/libraries/Wire/src/utility/twi.c
@@ -45,9 +45,11 @@ extern "C" {
 #endif
 
 /* Private Defines */
+
 /// @brief I2C timeout in tick unit
 #ifndef I2C_TIMEOUT_TICK
-#define I2C_TIMEOUT_TICK        100
+#define I2C_TIMEOUT_TICK        3      // MMOLE first used 10ms, now even much shorter timeout to facilitate I2C scanning
+//#define I2C_TIMEOUT_TICK        100
 #endif
 
 #define SLAVE_MODE_TRANSMIT     0
@@ -115,7 +117,6 @@ void i2c_custom_init(i2c_t *obj, uint32_t timing, uint32_t addressingMode, uint3
 {
   if (obj != NULL) 
   {
-  
     I2C_HandleTypeDef *handle = &(obj->handle);
     // Determine the I2C to use
     I2C_TypeDef *i2c_sda = pinmap_peripheral(obj->sda, PinMap_I2C_SDA);
@@ -185,13 +186,20 @@ void i2c_custom_init(i2c_t *obj, uint32_t timing, uint32_t addressingMode, uint3
         handle->Init.I2C_Ack             = I2C_Ack_Enable;
         handle->Init.I2C_AcknowledgedAddress = addressingMode;
 
-#if 0 
-        /* Interruption is temporarily not supported */ 
-        NVIC_SetPriority(obj->irq, I2C_IRQ_PRIO, I2C_IRQ_SUBPRIO);
-        NVIC_EnableIRQ(obj->irq);
+#if OPT_I2C_SLAVE // MMOLE: was 0 (all calls were commented out)
+		// MMOLE: enable/setup interrupts. Note: all lines within the if were commented out
+		if(obj->isMaster==0)
+		{
+          // MMOLE: Enable I2C interrupts (used value is supported by all CH32's; followed ch32v003fun i2c_slave example by @cnlohr)
+          obj->i2c->CTLR2 |= I2C_CTLR2_ITBUFEN | I2C_CTLR2_ITEVTEN | I2C_CTLR2_ITERREN;
+		  
+          /* Interruption is temporarily not supported */ 
+          //NVIC_SetPriority(obj->irq, I2C_IRQ_PRIO, I2C_IRQ_SUBPRIO);
+          NVIC_EnableIRQ(obj->irq); // Event interrupt
 
-        NVIC_SetPriority(obj->irqER, I2C_IRQ_PRIO, I2C_IRQ_SUBPRIO);
-        NVIC_EnableIRQ(obj->irqER);
+          //NVIC_SetPriority(obj->irqER, I2C_IRQ_PRIO, I2C_IRQ_SUBPRIO);
+          NVIC_EnableIRQ(obj->irqER); // Error interrupt
+		}
 #endif
 
         /* Init the I2C */
@@ -199,8 +207,8 @@ void i2c_custom_init(i2c_t *obj, uint32_t timing, uint32_t addressingMode, uint3
         I2C_Cmd(obj->i2c,ENABLE);
 
         /* Initialize default values */
-        // obj->slaveRxNbData = 0;
-        // obj->slaveMode = SLAVE_MODE_LISTEN;
+        //obj->slaveRxNbData = 0;		// MMOLE: was commented
+        //obj->slaveMode = SLAVE_MODE_LISTEN;		// MMOLE: was commented
       }
     }
   }
@@ -213,6 +221,8 @@ void i2c_custom_init(i2c_t *obj, uint32_t timing, uint32_t addressingMode, uint3
   */
 void i2c_deinit(i2c_t *obj)
 {
+  // MMOLE TODO: Disable I2C interrupts
+  // do reverse of this: obj->i2c->CTLR2 |= I2C_CTLR2_ITBUFEN | I2C_CTLR2_ITEVTEN | I2C_CTLR2_ITERREN;
   NVIC_DisableIRQ(obj->irq);
   NVIC_DisableIRQ(obj->irqER);
   I2C_DeInit(obj->i2c);
@@ -257,16 +267,28 @@ void i2c_setTiming(i2c_t *obj, uint32_t frequency)
   */
 i2c_status_e i2c_master_write(i2c_t *obj, uint8_t dev_address,
                               uint8_t *data, uint16_t size, uint8_t sendstop)
-
 {
+  // MMOLE: Added support for I2C scanning using Wire.endTransmission() without sending data
+  // Arduino examples: 
+  //    i2c_scanner by Nick Gammon (broken link: http://arduino-info.wikispaces.com/LCD-Blue-I2C), 
+  //    https://playground.arduino.cc/Main/I2cScanner/
+  //    https://learn.adafruit.com/scanning-i2c-addresses/arduino
+  // Inspiration from https://github.com/mockthebear/easy-ch32v003/tree/main/examples/i2c_scanner
+
+
   i2c_status_e  ret = I2C_OK;
   uint32_t tickstart = GetTick();
   {
     I2C_AcknowledgeConfig( obj->handle.Instance, ENABLE ); 
-    while(I2C_GetFlagStatus(obj->handle.Instance, I2C_FLAG_BUSY) != RESET)  //waite for busy
+    while(I2C_GetFlagStatus(obj->handle.Instance, I2C_FLAG_BUSY) != RESET)  //wait for busy
     {
         if((GetTick()-tickstart) > I2C_TIMEOUT_TICK) 
         {
+/**/
+// MMOLE: To allow I2C scanning, when a start condition times out the bus needs to be released
+          if(sendstop)  
+            I2C_GenerateSTOP(obj->handle.Instance, ENABLE);
+/**/
           return I2C_TIMEOUT;
         }
     }
@@ -276,6 +298,11 @@ i2c_status_e i2c_master_write(i2c_t *obj, uint8_t dev_address,
     {
         if((GetTick()-tickstart) > I2C_TIMEOUT_TICK) 
         {
+/**/
+// MMOLE: To allow I2C scanning, when a start condition times out the bus needs to be released
+          if(sendstop)  
+            I2C_GenerateSTOP(obj->handle.Instance, ENABLE);
+/**/
           return I2C_TIMEOUT;
         }
     }
@@ -285,10 +312,16 @@ i2c_status_e i2c_master_write(i2c_t *obj, uint8_t dev_address,
     {
         if((GetTick()-tickstart) > I2C_TIMEOUT_TICK) 
         {
+// MMOLE: To allow I2C scanning, timeout on an addresses should release the bus
+          if(sendstop)  
+            I2C_GenerateSTOP(obj->handle.Instance, ENABLE);
           return I2C_TIMEOUT;
         }
     }
 
+// MMOLE: Support for I2C scanning: allow only sending the address (without actual data)
+if(size)
+{  
     while(size)
     {
         if( I2C_GetFlagStatus(obj->handle.Instance, I2C_FLAG_TXE) != RESET )
@@ -306,6 +339,7 @@ i2c_status_e i2c_master_write(i2c_t *obj, uint8_t dev_address,
           return I2C_TIMEOUT;
         }
     }
+}   // if(size)
 
     if(sendstop)  
     {
@@ -322,12 +356,88 @@ i2c_status_e i2c_master_write(i2c_t *obj, uint8_t dev_address,
   * @param  size: number of bytes to be write.
   * @retval status
   */
+#if OPT_I2C_SLAVE
 i2c_status_e i2c_slave_write_IT(i2c_t *obj, uint8_t *data, uint16_t size)
 {
  
 
 }
+#endif // #if OPT_I2C_SLAVE
 
+#if OPT_I2C_SLAVE
+
+void i2c_ClearErrorFlags(i2c_t *obj)
+{   // clear the various error flags that may block further communication
+
+  if(I2C_GetFlagStatus( obj->i2c, I2C_FLAG_AF ) !=  RESET)
+  { //  I2C_FLAG_AF - Acknowledge failure flag.
+    I2C_ClearFlag( obj->i2c, I2C_FLAG_AF );
+  }
+  if(I2C_GetFlagStatus( obj->i2c, I2C_FLAG_BERR ) !=  RESET)
+  { //  I2C_FLAG_BERR -Bus Error flag.
+    I2C_ClearFlag( obj->i2c, I2C_FLAG_BERR );
+  }
+}
+
+void i2c_ClearStopFlag(i2c_t *obj)
+{   // clear the stop flag
+  if(I2C_GetFlagStatus( obj->i2c, I2C_FLAG_STOPF ) !=  RESET)
+  { // Stop detection flag (Slave mode).
+    // STOPF (STOP detection) is cleared by software sequence: a read operation 
+    // to I2C_STAR1 register (I2C_GetFlagStatus()) followed by a write operation 
+    // to I2C_CTLR1 register (I2C_Cmd() to re-enable the I2C peripheral).
+    // -> Since we just read the flag, we only need to (re-)enable.
+    I2C_Cmd(obj->i2c, ENABLE);
+  }
+}
+
+// MMOLE: added function to process I2C slave data transfers
+void i2c_slave_process(i2c_t *obj)
+{ // Process incoming and outgoing I2C data.
+  // When processing the data we can assume there is an address match.
+  // We could wait for an address match, but that would be blocking
+  // and isn't needed as RX/TX-flags are only set when addressed properly.
+
+  // Process receiving data
+  if(I2C_GetFlagStatus( obj->i2c, I2C_FLAG_RXNE ) !=  RESET)
+  { // Data register not empty (Receiver) flag; read all available data and store it
+    while(I2C_GetFlagStatus( obj->i2c, I2C_FLAG_RXNE ) !=  RESET)
+    {
+      char c=I2C_ReceiveData( obj->i2c );
+      if(obj->i2cTxRxBufferSize<I2C_TXRX_BUFFER_SIZE)
+      {
+        obj->i2cTxRxBuffer[obj->i2cTxRxBufferSize]=c;
+        obj->i2cTxRxBufferSize++;
+      }
+    }
+  }
+
+  // Process end of receiving data, as determined by stop flag
+  if(I2C_CheckEvent( obj->i2c, I2C_EVENT_SLAVE_STOP_DETECTED))
+  { // When done receiving let's do the callback
+    // Note: twi.c::i2c_onSlaveReceive is tied to the TwoWire::onReceiveService().
+    obj->slaveRxNbData=obj->i2cTxRxBufferSize; // remember so we can forget
+    obj->i2cTxRxBufferSize=0;   // reset the buffer for next incoming data
+    if(obj->slaveRxNbData>0 && obj->i2c_onSlaveReceive) obj->i2c_onSlaveReceive(obj);
+
+	// clear the stop flag to be ready for another session
+	i2c_ClearStopFlag(obj);
+  }
+
+  // Process transmitting data  
+  if(I2C_GetFlagStatus( obj->i2c, I2C_FLAG_TXE ) !=  RESET)
+  { // Data register empty flag (Transmitter).
+    // It seems we need to send something, give the callback opportunity to do so.
+    // Note: twi.c::i2c_onSlaveTransmit is tied to the TwoWire::onRequestService().
+    // The onRequest callback uses Wire.write(), which calls twi.c::i2c_slave_write(), 
+    // which then calls I2C_SendData() and checks if done within timeout */
+    if(obj->i2c_onSlaveTransmit) obj->i2c_onSlaveTransmit(obj);
+  }
+
+  // Clear error flags (since we don't handle them anyways)
+  i2c_ClearErrorFlags(obj);
+}
+#endif // #if OPT_I2C_SLAVE
 
 
 /**
@@ -339,6 +449,7 @@ i2c_status_e i2c_slave_write_IT(i2c_t *obj, uint8_t *data, uint16_t size)
   */
 i2c_status_e i2c_slave_write(i2c_t *obj, uint8_t *data, uint16_t size)
 {
+#if OPT_I2C_SLAVE
   uint8_t i = 0;
   i2c_status_e ret = I2C_OK;
   uint32_t tickstart = GetTick();
@@ -347,7 +458,6 @@ i2c_status_e i2c_slave_write(i2c_t *obj, uint8_t *data, uint16_t size)
   {
     I2C_SendData(obj->handle.Instance,data[i]);
     i++;
-
     
     while(!I2C_CheckEvent( obj->handle.Instance, I2C_EVENT_SLAVE_BYTE_TRANSMITTED ) )
     {
@@ -356,9 +466,22 @@ i2c_status_e i2c_slave_write(i2c_t *obj, uint8_t *data, uint16_t size)
         ret =  I2C_TIMEOUT;
         break;
       }
+
+//#if OPT_I2C_SLAVE
+      // don't wait too long. When the controller wants to read immediately there can be a new event (0x00060080) waiting
+      uint32_t evt=I2C_GetLastEvent(obj->i2c);
+      if(!evt)
+        break;
+      i2c_ClearErrorFlags(obj);
+      i2c_ClearStopFlag(obj);  // really needed here?
+//#endif // #if OPT_I2C_SLAVE
     }
+
+    //i2c_ClearErrorFlags(obj);
+    //i2c_ClearStopFlag(obj);  // really needed here?
   }
   return ret;
+#endif // #if OPT_I2C_SLAVE
 }
 
 
@@ -398,10 +521,19 @@ i2c_status_e i2c_master_read(i2c_t *obj, uint8_t dev_address, uint8_t *data, uin
       }
   }
 
+  I2C_AcknowledgeConfig( obj->handle.Instance, ENABLE );  //MMOLE fix: every byte except last needs to ACK, also on repeated reads
   while(size)
   {
       if(size==1) I2C_AcknowledgeConfig( obj->handle.Instance, DISABLE );  //last data needn't to ACK
-      while(I2C_GetFlagStatus( obj->handle.Instance, I2C_FLAG_RXNE ) ==  RESET);
+      while(I2C_GetFlagStatus( obj->handle.Instance, I2C_FLAG_RXNE ) ==  RESET)
+      {
+        // MMOLE: at occasion the CH32 would just hang while reading the response. Still unknown why. but adding a timeout may prevent this
+        if((GetTick()-tickstart) > I2C_TIMEOUT_TICK) 
+        {
+            I2C_GenerateSTOP( obj->handle.Instance, ENABLE );
+            return I2C_TIMEOUT;
+        }
+      }
       *data++ = I2C_ReceiveData( obj->handle.Instance );
       size--;
   }
@@ -419,6 +551,7 @@ i2c_status_e i2c_master_read(i2c_t *obj, uint8_t dev_address, uint8_t *data, uin
   */
 i2c_status_e i2c_slave_read(i2c_t *obj, uint8_t *data, uint16_t size)
 {
+#if OPT_I2C_SLAVE
   uint8_t i = 0;
   i2c_status_e ret = I2C_OK;
   uint32_t tickstart = GetTick();
@@ -438,6 +571,7 @@ i2c_status_e i2c_slave_read(i2c_t *obj, uint8_t *data, uint16_t size)
 
   }
   return ret;
+#endif // #if OPT_I2C_SLAVE
 }
 
 
@@ -477,7 +611,11 @@ i2c_t *get_i2c_obj(I2C_HandleTypeDef *hi2c)
   */
 void i2c_attachSlaveRxEvent(i2c_t *obj, void (*function)(i2c_t *))
 {
-  
+#if OPT_I2C_SLAVE
+  // MMOLE 240320: this is where we attach the Wire.onReceiveService to our i2c object
+  // The Wire.onReceiveService does the actual callback at the moment all data is receved.
+  obj->i2c_onSlaveReceive=function;
+#endif
 }
 
 /** @brief  sets function called before a slave write operation
@@ -487,7 +625,11 @@ void i2c_attachSlaveRxEvent(i2c_t *obj, void (*function)(i2c_t *))
   */
 void i2c_attachSlaveTxEvent(i2c_t *obj, void (*function)(i2c_t *))
 {
-  
+#if OPT_I2C_SLAVE
+  // MMOLE 240320: this is where we attach the Wire.onRequestService to our i2c object
+  // The Wire.onRequestService does the actual callback at the moment data needs to be transmitted.
+  obj->i2c_onSlaveTransmit=function;
+#endif
 }
 
 
@@ -501,8 +643,14 @@ void i2c_attachSlaveTxEvent(i2c_t *obj, void (*function)(i2c_t *))
 void I2C1_EV_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
 void I2C1_EV_IRQHandler(void)
 {
-  // I2C_HandleTypeDef *handle = i2c_handles[I2C1_INDEX];
-}
+#if OPT_I2C_SLAVE
+   I2C_HandleTypeDef *handle = i2c_handles[I2C1_INDEX];  // MMOLE: was commented
+   // MMOLE: I2C1_EV_IRQHandler is the event handler, handle is an I2C_HandleTypeDef struct containing parameters and pointer to the registers
+   static int _nCounterEV1=1;
+   _nCounterEV1++;
+   i2c_slave_process(get_i2c_obj(handle));		// process I2C transmissions, for now only events, not errors
+#endif
+ }
 /**
 * @brief  This function handles I2C1 interrupt.
 * @param  None
@@ -511,7 +659,12 @@ void I2C1_EV_IRQHandler(void)
 void I2C1_ER_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
 void I2C1_ER_IRQHandler(void)
 {
-  // I2C_HandleTypeDef *handle = i2c_handles[I2C1_INDEX];
+#if OPT_I2C_SLAVE
+   //I2C_HandleTypeDef *handle = i2c_handles[I2C1_INDEX];  // MMOLE: was commented
+   // MMOLE: I2C1_ER_IRQHandler is the error handler
+   static int _nCounterER1=1;
+   _nCounterER1++;
+#endif
 }
 #endif // I2C1_BASE
 
@@ -525,7 +678,14 @@ void I2C1_ER_IRQHandler(void)
 void I2C2_EV_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
 void I2C2_EV_IRQHandler(void)
 {
-  // I2C_HandleTypeDef *handle = i2c_handles[I2C2_INDEX];
+#if OPT_I2C_SLAVE
+   //I2C_HandleTypeDef *handle = i2c_handles[I2C2_INDEX];  // MMOLE: was commented
+   // MMOLE: I2C2_EV_IRQHandler is the event handler, handle is an I2C_HandleTypeDef struct containing parameters and pointer to the registers
+   static int _nCounterEV2=1;
+   _nCounterEV2++;
+   i2c_slave_process(get_i2c_obj(handle));		// process I2C transmissions, for now only events, not errors
+   // MMOLLE: tested only using I2C1
+#endif
 }
 
 /**
@@ -536,7 +696,12 @@ void I2C2_EV_IRQHandler(void)
 void I2C2_ER_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
 void I2C2_ER_IRQHandler(void)
 {
-  // I2C_HandleTypeDef *handle = i2c_handles[I2C2_INDEX];
+#if OPT_I2C_SLAVE
+   //I2C_HandleTypeDef *handle = i2c_handles[I2C2_INDEX];  // MMOLE: was commented
+   // MMOLE: I2C2_ER_IRQHandler is the error handler
+   static int _nCounterER2=1;
+   _nCounterER2++;
+#endif
 }
 
 #endif // I2C2_BASE

--- a/libraries/Wire/src/utility/twi.h
+++ b/libraries/Wire/src/utility/twi.h
@@ -50,6 +50,12 @@
 extern "C" {
 #endif
 
+// enabling callback attachment, set slave interrupts, process data transfers
+#ifndef OPT_I2C_SLAVE			// allow setting define using Arduino IDE menu choice
+#define OPT_I2C_SLAVE 1			// set to 0 to save about 1K FLASH space (812 bytes used with -Os)
+#endif
+
+
 /* Exported types ------------------------------------------------------------*/
 /* offsetof is a gcc built-in function, this is the manual implementation */
 #define OFFSETOF(type, member) ((uint32_t) (&(((type *)(0))->member)))
@@ -96,8 +102,9 @@ struct i2c_s {
   void (*i2c_onSlaveTransmit)(i2c_t *);
   volatile uint8_t i2cTxRxBuffer[I2C_TXRX_BUFFER_SIZE];
   volatile uint8_t i2cTxRxBufferSize;
+#if OPT_I2C_SLAVE
   volatile uint8_t slaveMode;
-  
+#endif // #if OPT_I2C_SLAVE  
   uint8_t isMaster;
   uint8_t generalCall;
   uint8_t NoStretchMode;
@@ -131,6 +138,12 @@ i2c_status_e i2c_slave_read(i2c_t *obj, uint8_t *data, uint16_t size);
 // i2c_status_e i2c_IsDeviceReady(i2c_t *obj, uint8_t devAddr, uint32_t trials);
 void i2c_attachSlaveRxEvent(i2c_t *obj, void (*function)(i2c_t *));
 void i2c_attachSlaveTxEvent(i2c_t *obj, void (*function)(i2c_t *));
+
+// MMOLE 240320: was this method private?
+i2c_t *get_i2c_obj(I2C_HandleTypeDef *);
+
+// MMOLE 240323: call this to process slave data transfers
+//void i2c_slave_process(i2c_t *obj);
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
This PR includes:
1. changes to enable i2c scanning when used as master and example to demonstrate
2. changes to enable i2c slave mode and example to demonstrate

Note: having i2c slave mode will increase the flash footprint, even when not used as slave. To regain this flash memory when not used, the option OPT_I2C_SLAVE should be set to 0 in twi.h (or through a setting in the IDE, but at the moment this is not implemented yet):

```
#ifndef OPT_I2C_SLAVE			// allow setting define using Arduino IDE menu choice
#define OPT_I2C_SLAVE 1			// set to 0 to save about 1K FLASH space (812 bytes used with -Os)
#endif

```

NOTE: These changes were only tested using the CH32V003. Unfortunately I have no other CH32 chips to test with.
Some parts of the implementation are not very refined. However, something working is better than nothing. For that reason the changes include comments to allow identification and later improvements.