### PR TITLE
call yield in delay()

### DIFF
--- a/cores/arduino/wiring_time.c
+++ b/cores/arduino/wiring_time.c
@@ -39,7 +39,7 @@ void delay(uint32_t ms)
   if (ms != 0) {
     uint32_t start = getCurrentMillis();
     do {
-      // yield();
+      yield();
     } while (getCurrentMillis() - start < ms);
   }
 }


### PR DESCRIPTION
hihi, I am working on adding Adafruit_TinyUSB support for this core. Calling yield() in delay() to allow libraries (e.g tinyusb) to run background task