### PR TITLE
add ARDUINO_ARCH_CH32 define

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -89,7 +89,7 @@ build.pid=0
 
 # Build information's     
 #####################-D{build.board} -DARDUINO_ARCH_{build.arch} -DBOARD_NAME="{build.board}" -DVARIANT_H="{build.variant_h}"
-build.info.flags=-D{build.series} -DARDUINO={runtime.ide.version} -D{build.chip} -DVARIANT_H="{build.variant_h}"
+build.info.flags=-DARDUINO_ARCH_CH32 -D{build.series} -DARDUINO={runtime.ide.version} -D{build.chip} -DVARIANT_H="{build.variant_h}"
 
 # Defaults config
 build.xSerial=


### PR DESCRIPTION
hihi, I am working on adding Adafruit_TinyUSB support for this core. Adding ARDUINO_ARCH_CH32 make it easier for libraries e.g tinyusb to detect which platform it is compiled with/