### PR TITLE
Add tinyusb builtin-core support with menu selection

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "libraries/Adafruit_TinyUSB_Arduino"]
+	path = libraries/Adafruit_TinyUSB_Arduino
+	url = https://github.com/adafruit/Adafruit_TinyUSB_Arduino.git

--- a/boards.txt
+++ b/boards.txt
@@ -493,6 +493,14 @@ CH32V20x_EVT.menu.pnum.CH32V203C6.build.IQ_math_RV32=
 CH32V20x_EVT.menu.pnum.CH32V203C6.build.ch_extra_lib=-lprintf
 
 
+# USB support
+CH32V20x_EVT.menu.usb.none=None
+CH32V20x_EVT.menu.usb.none.build.usb_flags=
+CH32V20x_EVT.menu.usb.tinyusb_usbd=Adafruit TinyUSB with USBD
+CH32V20x_EVT.menu.usb.tinyusb_usbd.build.usb_flags=-DUSBCON -DUSE_TINYUSB -DCFG_TUD_WCH_USBIP_FSDEV=1 "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+CH32V20x_EVT.menu.usb.tinyusb_usbfs=Adafruit TinyUSB with USBFS
+CH32V20x_EVT.menu.usb.tinyusb_usbfs.build.usb_flags=-DUSBCON -DUSE_TINYUSB -DCFG_TUD_WCH_USBIP_USBFS=1 "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+
 # Upload menu
 CH32V20x_EVT.menu.upload_method.swdMethod=WCH-SWD
 CH32V20x_EVT.menu.upload_method.swdMethod.upload.protocol=

--- a/boards.txt
+++ b/boards.txt
@@ -14,8 +14,8 @@ menu.upload_method=Upload method
 
 
 
-#############################################################################
-##CH32V00x EVT Board
+##############################################################################
+##CH32V00x_EVT Board   
 
 CH32V00x_EVT.name=CH32V00x
 CH32V00x_EVT.build.core=arduino
@@ -38,7 +38,7 @@ CH32V00x_EVT.menu.pnum.CH32V003F4.build.variant=CH32V00x/CH32V003F4
 CH32V00x_EVT.menu.pnum.CH32V003F4.build.chip=CH32V003F4
 CH32V00x_EVT.menu.pnum.CH32V003F4.build.march=rv32ecxw
 CH32V00x_EVT.menu.pnum.CH32V003F4.build.mabi=ilp32e
-CH32V00x_EVT.menu.pnum.CH32V003F4.build.math_lib_gcc=-lm 
+CH32V00x_EVT.menu.pnum.CH32V003F4.build.math_lib_gcc=-lm
 CH32V00x_EVT.menu.pnum.CH32V003F4.build.IQ_math_RV32=
 CH32V00x_EVT.menu.pnum.CH32V003F4.build.ch_extra_lib=-lprintf
 
@@ -50,9 +50,24 @@ CH32V00x_EVT.menu.upload_method.swdMethod.upload.options=
 CH32V00x_EVT.menu.upload_method.swdMethod.upload.tool=WCH_linkE
 
 
+# Clock Select
+CH32V00x_EVT.menu.clock.48MHz_HSI=48MHz Internal
+CH32V00x_EVT.menu.clock.48MHz_HSI.build.flags.clock=-DSYSCLK_FREQ_48MHz_HSI=48000000
+CH32V00x_EVT.menu.clock.24MHz_HSI=24MHz Internal
+CH32V00x_EVT.menu.clock.24MHz_HSI.build.flags.clock=-DSYSCLK_FREQ_24MHz_HSI=24000000
+CH32V00x_EVT.menu.clock.8MHz_HSI=8MHz Internal
+CH32V00x_EVT.menu.clock.8MHz_HSI.build.flags.clock=-DSYSCLK_FREQ_8MHz_HSI=8000000
+CH32V00x_EVT.menu.clock.48MHz_HSE=48MHz External
+CH32V00x_EVT.menu.clock.48MHz_HSE.build.flags.clock=-DSYSCLK_FREQ_48MHz_HSE=48000000
+CH32V00x_EVT.menu.clock.24MHz_HSE=24MHz External
+CH32V00x_EVT.menu.clock.24MHz_HSE.build.flags.clock=-DSYSCLK_FREQ_24MHz_HSE=24000000
+CH32V00x_EVT.menu.clock.8MHz_HSE=8MHz External
+CH32V00x_EVT.menu.clock.8MHz_HSE.build.flags.clock=-DSYSCLK_FREQ_8MHz_HSE=8000000
+
+
 # Optimizations
 CH32V00x_EVT.menu.opt.osstd=Smallest (-Os default)
-CH32V00x_EVT.menu.opt.osstd.build.flags.optimize=-Os 
+CH32V00x_EVT.menu.opt.osstd.build.flags.optimize=-Os
 CH32V00x_EVT.menu.opt.oslto=Smallest (-Os) with LTO
 CH32V00x_EVT.menu.opt.oslto.build.flags.optimize=-Os -flto
 CH32V00x_EVT.menu.opt.o1std=Fast (-O1)
@@ -72,23 +87,10 @@ CH32V00x_EVT.menu.opt.ogstd.build.flags.optimize=-Og
 CH32V00x_EVT.menu.opt.o0std=No Optimization (-O0)
 CH32V00x_EVT.menu.opt.o0std.build.flags.optimize=-O0
 
-# Clock Select 
-CH32V00x_EVT.menu.clock.48MHz_HSI=48MHz Internal
-CH32V00x_EVT.menu.clock.48MHz_HSI.build.flags.clock=-DSYSCLK_FREQ_48MHz_HSI=48000000
-CH32V00x_EVT.menu.clock.24MHz_HSI=24MHz Internal
-CH32V00x_EVT.menu.clock.24MHz_HSI.build.flags.clock=-DSYSCLK_FREQ_24MHz_HSI=24000000
-CH32V00x_EVT.menu.clock.8MHz_HSI=8MHz Internal
-CH32V00x_EVT.menu.clock.8MHz_HSI.build.flags.clock=-DSYSCLK_FREQ_8MHz_HSI=8000000
-CH32V00x_EVT.menu.clock.48MHz_HSE=48MHz External
-CH32V00x_EVT.menu.clock.48MHz_HSE.build.flags.clock=-DSYSCLK_FREQ_48MHz_HSE=48000000
-CH32V00x_EVT.menu.clock.24MHz_HSE=24MHz External
-CH32V00x_EVT.menu.clock.24MHz_HSE.build.flags.clock=-DSYSCLK_FREQ_24MHz_HSE=24000000
-CH32V00x_EVT.menu.clock.8MHz_HSE=8MHz External
-CH32V00x_EVT.menu.clock.8MHz_HSE.build.flags.clock=-DSYSCLK_FREQ_8MHz_HSE=8000000
 
 # Debug information
 CH32V00x_EVT.menu.dbg.none=None
-CH32V00x_EVT.menu.dbg.none.build.flags.debug=-DNDEBUG 
+CH32V00x_EVT.menu.dbg.none.build.flags.debug=-DNDEBUG
 CH32V00x_EVT.menu.dbg.enable_sym=Symbols Enabled (-g)
 CH32V00x_EVT.menu.dbg.enable_sym.build.flags.debug=-g -DNDEBUG
 CH32V00x_EVT.menu.dbg.enable_log=Core logs Enabled
@@ -111,8 +113,9 @@ CH32V00x_EVT.menu.rtlib.full.build.flags.ldflags=--specs=nosys.specs
 
 
 
-#############################################################################
-##CH32V/M00X EVT Board   including V/M 002 004 005 006 007
+
+##############################################################################
+##CH32VM00X_EVT Board   including V/M 002 004 005 006 007
 
 CH32VM00X_EVT.name=CH32VM00X
 CH32VM00X_EVT.build.core=arduino
@@ -123,8 +126,7 @@ CH32VM00X_EVT.build.variant_h=variant_{build.board}.h
 CH32VM00X_EVT.debug.tool=gdb-WCH_LinkE
 
 
-#CH32V006K8 EVT Board  62KB-FLASH 8KB-SRAM    rv32ec_zmmul_xw  
-#Temporary compilation using the compilation parameters of 003
+#CH32V006K8 EVT Board
 CH32VM00X_EVT.menu.pnum.CH32V006K8=CH32V006K8 EVT
 CH32VM00X_EVT.menu.pnum.CH32V006K8.node=NODE_V006K8
 CH32VM00X_EVT.menu.pnum.CH32V006K8.upload.maximum_size=63488
@@ -136,7 +138,7 @@ CH32VM00X_EVT.menu.pnum.CH32V006K8.build.variant=CH32VM00X/CH32V006K8
 CH32VM00X_EVT.menu.pnum.CH32V006K8.build.chip=CH32V006K8
 CH32VM00X_EVT.menu.pnum.CH32V006K8.build.march=rv32ecxw
 CH32VM00X_EVT.menu.pnum.CH32V006K8.build.mabi=ilp32e
-CH32VM00X_EVT.menu.pnum.CH32V006K8.build.math_lib_gcc=-lm 
+CH32VM00X_EVT.menu.pnum.CH32V006K8.build.math_lib_gcc=-lm
 CH32VM00X_EVT.menu.pnum.CH32V006K8.build.IQ_math_RV32=
 CH32VM00X_EVT.menu.pnum.CH32V006K8.build.ch_extra_lib=-lprintf
 
@@ -148,7 +150,7 @@ CH32VM00X_EVT.menu.upload_method.swdMethod.upload.options=
 CH32VM00X_EVT.menu.upload_method.swdMethod.upload.tool=WCH_linkE
 
 
-# Clock Select 
+# Clock Select
 CH32VM00X_EVT.menu.clock.48MHz_HSI=48MHz Internal
 CH32VM00X_EVT.menu.clock.48MHz_HSI.build.flags.clock=-DSYSCLK_FREQ_48MHz_HSI=48000000
 CH32VM00X_EVT.menu.clock.24MHz_HSI=24MHz Internal
@@ -165,7 +167,7 @@ CH32VM00X_EVT.menu.clock.8MHz_HSE.build.flags.clock=-DSYSCLK_FREQ_8MHz_HSE=80000
 
 # Optimizations
 CH32VM00X_EVT.menu.opt.osstd=Smallest (-Os default)
-CH32VM00X_EVT.menu.opt.osstd.build.flags.optimize=-Os 
+CH32VM00X_EVT.menu.opt.osstd.build.flags.optimize=-Os
 CH32VM00X_EVT.menu.opt.oslto=Smallest (-Os) with LTO
 CH32VM00X_EVT.menu.opt.oslto.build.flags.optimize=-Os -flto
 CH32VM00X_EVT.menu.opt.o1std=Fast (-O1)
@@ -188,7 +190,7 @@ CH32VM00X_EVT.menu.opt.o0std.build.flags.optimize=-O0
 
 # Debug information
 CH32VM00X_EVT.menu.dbg.none=None
-CH32VM00X_EVT.menu.dbg.none.build.flags.debug=-DNDEBUG 
+CH32VM00X_EVT.menu.dbg.none.build.flags.debug=-DNDEBUG
 CH32VM00X_EVT.menu.dbg.enable_sym=Symbols Enabled (-g)
 CH32VM00X_EVT.menu.dbg.enable_sym.build.flags.debug=-g -DNDEBUG
 CH32VM00X_EVT.menu.dbg.enable_log=Core logs Enabled
@@ -210,8 +212,10 @@ CH32VM00X_EVT.menu.rtlib.full=Newlib Standard
 CH32VM00X_EVT.menu.rtlib.full.build.flags.ldflags=--specs=nosys.specs
 
 
-#############################################################################
-##CH32X035 EVT Board
+
+
+##############################################################################
+##CH32X035_EVT Board   
 
 CH32X035_EVT.name=CH32X035
 CH32X035_EVT.build.core=arduino
@@ -221,9 +225,10 @@ CH32X035_EVT.upload.maximum_data_size=0
 CH32X035_EVT.build.variant_h=variant_{build.board}.h
 CH32X035_EVT.debug.tool=gdb-WCH_LinkE
 
-#CH32X035 EVT Board
+
+#CH32X035G8U EVT Board
 CH32X035_EVT.menu.pnum.CH32X035G8U=CH32X035G8U EVT
-CH32X035_EVT.menu.pnum.CH32X035G8U.node=NODE_X035G8
+CH32X035_EVT.menu.pnum.CH32X035G8U.node=NODE_X035G8U
 CH32X035_EVT.menu.pnum.CH32X035G8U.upload.maximum_size=63488
 CH32X035_EVT.menu.pnum.CH32X035G8U.upload.maximum_data_size=20480
 CH32X035_EVT.menu.pnum.CH32X035G8U.build.mcu=QingKe-V4C
@@ -233,7 +238,7 @@ CH32X035_EVT.menu.pnum.CH32X035G8U.build.variant=CH32X035/CH32X035G8U
 CH32X035_EVT.menu.pnum.CH32X035G8U.build.chip=CH32X035G8U
 CH32X035_EVT.menu.pnum.CH32X035G8U.build.march=rv32imacxw
 CH32X035_EVT.menu.pnum.CH32X035G8U.build.mabi=ilp32
-CH32X035_EVT.menu.pnum.CH32X035G8U.build.math_lib_gcc=-lm 
+CH32X035_EVT.menu.pnum.CH32X035G8U.build.math_lib_gcc=-lm
 CH32X035_EVT.menu.pnum.CH32X035G8U.build.IQ_math_RV32=
 CH32X035_EVT.menu.pnum.CH32X035G8U.build.ch_extra_lib=-lprintf
 
@@ -244,22 +249,23 @@ CH32X035_EVT.menu.upload_method.swdMethod.upload.protocol=
 CH32X035_EVT.menu.upload_method.swdMethod.upload.options=
 CH32X035_EVT.menu.upload_method.swdMethod.upload.tool=WCH_linkE
 
-# Clock Select 
+
+# Clock Select
 CH32X035_EVT.menu.clock.48MHz_HSI=48MHz Internal
 CH32X035_EVT.menu.clock.48MHz_HSI.build.flags.clock=-DSYSCLK_FREQ_48MHz_HSI=48000000
 CH32X035_EVT.menu.clock.24MHz_HSI=24MHz Internal
 CH32X035_EVT.menu.clock.24MHz_HSI.build.flags.clock=-DSYSCLK_FREQ_24MHz_HSI=24000000
-CH32X035_EVT.menu.clock.24MHz_HSI=16MHz Internal
-CH32X035_EVT.menu.clock.24MHz_HSI.build.flags.clock=-DSYSCLK_FREQ_16MHz_HSI=16000000
-CH32X035_EVT.menu.clock.24MHz_HSI=12MHz Internal
-CH32X035_EVT.menu.clock.24MHz_HSI.build.flags.clock=-DSYSCLK_FREQ_12MHz_HSI=12000000
+CH32X035_EVT.menu.clock.16MHz_HSI=16MHz Internal
+CH32X035_EVT.menu.clock.16MHz_HSI.build.flags.clock=-DSYSCLK_FREQ_16MHz_HSI=16000000
+CH32X035_EVT.menu.clock.12MHz_HSI=12MHz Internal
+CH32X035_EVT.menu.clock.12MHz_HSI.build.flags.clock=-DSYSCLK_FREQ_12MHz_HSI=12000000
 CH32X035_EVT.menu.clock.8MHz_HSI=8MHz Internal
 CH32X035_EVT.menu.clock.8MHz_HSI.build.flags.clock=-DSYSCLK_FREQ_8MHz_HSI=8000000
 
 
 # Optimizations
 CH32X035_EVT.menu.opt.osstd=Smallest (-Os default)
-CH32X035_EVT.menu.opt.osstd.build.flags.optimize=-Os 
+CH32X035_EVT.menu.opt.osstd.build.flags.optimize=-Os
 CH32X035_EVT.menu.opt.oslto=Smallest (-Os) with LTO
 CH32X035_EVT.menu.opt.oslto.build.flags.optimize=-Os -flto
 CH32X035_EVT.menu.opt.o1std=Fast (-O1)
@@ -282,7 +288,7 @@ CH32X035_EVT.menu.opt.o0std.build.flags.optimize=-O0
 
 # Debug information
 CH32X035_EVT.menu.dbg.none=None
-CH32X035_EVT.menu.dbg.none.build.flags.debug=-DNDEBUG 
+CH32X035_EVT.menu.dbg.none.build.flags.debug=-DNDEBUG
 CH32X035_EVT.menu.dbg.enable_sym=Symbols Enabled (-g)
 CH32X035_EVT.menu.dbg.enable_sym.build.flags.debug=-g -DNDEBUG
 CH32X035_EVT.menu.dbg.enable_log=Core logs Enabled
@@ -305,8 +311,9 @@ CH32X035_EVT.menu.rtlib.full.build.flags.ldflags=--specs=nosys.specs
 
 
 
-#############################################################################
-##CH32V10x EVT Board   -lprintf
+
+##############################################################################
+##CH32V10x_EVT Board   -lprintf, CH32V10x_3V3: 3.3V power supply  CH32V10x_5V: 5V power supply
 
 CH32V10x_EVT.name=CH32V10x
 CH32V10x_EVT.build.core=arduino
@@ -316,7 +323,8 @@ CH32V10x_EVT.upload.maximum_data_size=0
 CH32V10x_EVT.build.variant_h=variant_{build.board}.h
 CH32V10x_EVT.debug.tool=gdb-WCH_LinkE
 
-#CH32V103R8T6 EVT Board    CH32V10x_3V3: 3.3V power supply  CH32V10x_5V: 5V power supply
+
+#CH32V103R8T6 EVT Board
 CH32V10x_EVT.menu.pnum.CH32V103R8T6=CH32V103R8T6 EVT
 CH32V10x_EVT.menu.pnum.CH32V103R8T6.node=NODE_V103R8T6
 CH32V10x_EVT.menu.pnum.CH32V103R8T6.upload.maximum_size=65536
@@ -328,9 +336,9 @@ CH32V10x_EVT.menu.pnum.CH32V103R8T6.build.variant=CH32V10x/CH32V103R8T6
 CH32V10x_EVT.menu.pnum.CH32V103R8T6.build.chip=CH32V10x_3V3
 CH32V10x_EVT.menu.pnum.CH32V103R8T6.build.march=rv32imac
 CH32V10x_EVT.menu.pnum.CH32V103R8T6.build.mabi=ilp32
-CH32V10x_EVT.menu.pnum.CH32V103R8T6.build.math_lib_gcc=-lm 
+CH32V10x_EVT.menu.pnum.CH32V103R8T6.build.math_lib_gcc=-lm
 CH32V10x_EVT.menu.pnum.CH32V103R8T6.build.IQ_math_RV32=
-CH32V10x_EVT.menu.pnum.CH32V103R8T6.build.ch_extra_lib=-lprintf                           
+CH32V10x_EVT.menu.pnum.CH32V103R8T6.build.ch_extra_lib=-lprintf
 
 
 # Upload menu
@@ -339,7 +347,8 @@ CH32V10x_EVT.menu.upload_method.swdMethod.upload.protocol=
 CH32V10x_EVT.menu.upload_method.swdMethod.upload.options=
 CH32V10x_EVT.menu.upload_method.swdMethod.upload.tool=WCH_linkE
 
-# Clock Select 
+
+# Clock Select
 CH32V10x_EVT.menu.clock.72MHz_HSI=72MHz Internal
 CH32V10x_EVT.menu.clock.72MHz_HSI.build.flags.clock=-DSYSCLK_FREQ_72MHz_HSI=72000000
 CH32V10x_EVT.menu.clock.56MHz_HSI=56MHz Internal
@@ -347,7 +356,7 @@ CH32V10x_EVT.menu.clock.56MHz_HSI.build.flags.clock=-DSYSCLK_FREQ_56MHz_HSI=5600
 CH32V10x_EVT.menu.clock.48MHz_HSI=48MHz Internal
 CH32V10x_EVT.menu.clock.48MHz_HSI.build.flags.clock=-DSYSCLK_FREQ_48MHz_HSI=48000000
 CH32V10x_EVT.menu.clock.8MHz_HSI=8MHz Internal
-CH32V10x_EVT.menu.clock.8MHz_HSI.build.flags.clock=-DSYSCLK_FREQ_HSI=8000000
+CH32V10x_EVT.menu.clock.8MHz_HSI.build.flags.clock=-DSYSCLK_FREQ_8MHz_HSI=8000000
 CH32V10x_EVT.menu.clock.72MHz_HSE=72MHz External
 CH32V10x_EVT.menu.clock.72MHz_HSE.build.flags.clock=-DSYSCLK_FREQ_72MHz_HSE=72000000
 CH32V10x_EVT.menu.clock.56MHz_HSE=56MHz External
@@ -355,12 +364,12 @@ CH32V10x_EVT.menu.clock.56MHz_HSE.build.flags.clock=-DSYSCLK_FREQ_56MHz_HSE=5600
 CH32V10x_EVT.menu.clock.48MHz_HSE=48MHz External
 CH32V10x_EVT.menu.clock.48MHz_HSE.build.flags.clock=-DSYSCLK_FREQ_48MHz_HSE=48000000
 CH32V10x_EVT.menu.clock.8MHz_HSE=8MHz External
-CH32V10x_EVT.menu.clock.8MHz_HSE.build.flags.clock=-DSYSCLK_FREQ_HSE=8000000
+CH32V10x_EVT.menu.clock.8MHz_HSE.build.flags.clock=-DSYSCLK_FREQ_8MHz_HSE=8000000
 
 
 # Optimizations
 CH32V10x_EVT.menu.opt.osstd=Smallest (-Os default)
-CH32V10x_EVT.menu.opt.osstd.build.flags.optimize=-Os 
+CH32V10x_EVT.menu.opt.osstd.build.flags.optimize=-Os
 CH32V10x_EVT.menu.opt.oslto=Smallest (-Os) with LTO
 CH32V10x_EVT.menu.opt.oslto.build.flags.optimize=-Os -flto
 CH32V10x_EVT.menu.opt.o1std=Fast (-O1)
@@ -383,7 +392,7 @@ CH32V10x_EVT.menu.opt.o0std.build.flags.optimize=-O0
 
 # Debug information
 CH32V10x_EVT.menu.dbg.none=None
-CH32V10x_EVT.menu.dbg.none.build.flags.debug=-DNDEBUG 
+CH32V10x_EVT.menu.dbg.none.build.flags.debug=-DNDEBUG
 CH32V10x_EVT.menu.dbg.enable_sym=Symbols Enabled (-g)
 CH32V10x_EVT.menu.dbg.enable_sym.build.flags.debug=-g -DNDEBUG
 CH32V10x_EVT.menu.dbg.enable_log=Core logs Enabled
@@ -407,10 +416,8 @@ CH32V10x_EVT.menu.rtlib.full.build.flags.ldflags=--specs=nosys.specs
 
 
 
-
-
-#############################################################################
-##CH32V20x EVT Board
+##############################################################################
+##CH32V20x_EVT Board   
 
 CH32V20x_EVT.name=CH32V20x
 CH32V20x_EVT.build.core=arduino
@@ -419,6 +426,7 @@ CH32V20x_EVT.upload.maximum_size=0
 CH32V20x_EVT.upload.maximum_data_size=0
 CH32V20x_EVT.build.variant_h=variant_{build.board}.h
 CH32V20x_EVT.debug.tool=gdb-WCH_LinkE
+
 
 #CH32V203RB EVT Board
 CH32V20x_EVT.menu.pnum.CH32V203RB=CH32V203RB EVT
@@ -436,8 +444,6 @@ CH32V20x_EVT.menu.pnum.CH32V203RB.build.math_lib_gcc=-lm
 CH32V20x_EVT.menu.pnum.CH32V203RB.build.IQ_math_RV32=
 CH32V20x_EVT.menu.pnum.CH32V203RB.build.ch_extra_lib=-lprintf
 
-
-
 #CH32V203G8 EVT Board
 CH32V20x_EVT.menu.pnum.CH32V203G8=CH32V203G8 EVT
 CH32V20x_EVT.menu.pnum.CH32V203G8.node=NODE_V203G8
@@ -450,13 +456,11 @@ CH32V20x_EVT.menu.pnum.CH32V203G8.build.variant=CH32V20x/CH32V203G8
 CH32V20x_EVT.menu.pnum.CH32V203G8.build.chip=CH32V203
 CH32V20x_EVT.menu.pnum.CH32V203G8.build.march=rv32imacxw
 CH32V20x_EVT.menu.pnum.CH32V203G8.build.mabi=ilp32
-CH32V20x_EVT.menu.pnum.CH32V203G8.build.math_lib_gcc=-lm 
+CH32V20x_EVT.menu.pnum.CH32V203G8.build.math_lib_gcc=-lm
 CH32V20x_EVT.menu.pnum.CH32V203G8.build.IQ_math_RV32=
 CH32V20x_EVT.menu.pnum.CH32V203G8.build.ch_extra_lib=-lprintf
 
-
-
-#Generic CH32V203C8 Board
+#CH32V203C8 Board
 CH32V20x_EVT.menu.pnum.CH32V203C8=CH32V203C8
 CH32V20x_EVT.menu.pnum.CH32V203C8.node=NODE_V203C8
 CH32V20x_EVT.menu.pnum.CH32V203C8.upload.maximum_size=65536
@@ -468,12 +472,11 @@ CH32V20x_EVT.menu.pnum.CH32V203C8.build.variant=CH32V20x/CH32V203C8
 CH32V20x_EVT.menu.pnum.CH32V203C8.build.chip=CH32V203
 CH32V20x_EVT.menu.pnum.CH32V203C8.build.march=rv32imacxw
 CH32V20x_EVT.menu.pnum.CH32V203C8.build.mabi=ilp32
-CH32V20x_EVT.menu.pnum.CH32V203C8.build.math_lib_gcc=-lm 
+CH32V20x_EVT.menu.pnum.CH32V203C8.build.math_lib_gcc=-lm
 CH32V20x_EVT.menu.pnum.CH32V203C8.build.IQ_math_RV32=
 CH32V20x_EVT.menu.pnum.CH32V203C8.build.ch_extra_lib=-lprintf
 
-
-#Generic CH32V203C6 Board
+#CH32V203C6 Board
 CH32V20x_EVT.menu.pnum.CH32V203C6=CH32V203C6
 CH32V20x_EVT.menu.pnum.CH32V203C6.node=NODE_V203C6
 CH32V20x_EVT.menu.pnum.CH32V203C6.upload.maximum_size=32768
@@ -485,10 +488,9 @@ CH32V20x_EVT.menu.pnum.CH32V203C6.build.variant=CH32V20x/CH32V203C6
 CH32V20x_EVT.menu.pnum.CH32V203C6.build.chip=CH32V203
 CH32V20x_EVT.menu.pnum.CH32V203C6.build.march=rv32imacxw
 CH32V20x_EVT.menu.pnum.CH32V203C6.build.mabi=ilp32
-CH32V20x_EVT.menu.pnum.CH32V203C6.build.math_lib_gcc=-lm 
+CH32V20x_EVT.menu.pnum.CH32V203C6.build.math_lib_gcc=-lm
 CH32V20x_EVT.menu.pnum.CH32V203C6.build.IQ_math_RV32=
 CH32V20x_EVT.menu.pnum.CH32V203C6.build.ch_extra_lib=-lprintf
-
 
 
 # Upload menu
@@ -498,7 +500,7 @@ CH32V20x_EVT.menu.upload_method.swdMethod.upload.options=
 CH32V20x_EVT.menu.upload_method.swdMethod.upload.tool=WCH_linkE
 
 
-# Clock Select 
+# Clock Select
 CH32V20x_EVT.menu.clock.144MHz_HSI=144MHz Internal
 CH32V20x_EVT.menu.clock.144MHz_HSI.build.flags.clock=-DSYSCLK_FREQ_144MHz_HSI=144000000
 CH32V20x_EVT.menu.clock.120MHz_HSI=120MHz Internal
@@ -531,7 +533,7 @@ CH32V20x_EVT.menu.clock.HSE.build.flags.clock=-DSYSCLK_FREQ_HSE=HSE_VALUE
 
 # Optimizations
 CH32V20x_EVT.menu.opt.osstd=Smallest (-Os default)
-CH32V20x_EVT.menu.opt.osstd.build.flags.optimize=-Os 
+CH32V20x_EVT.menu.opt.osstd.build.flags.optimize=-Os
 CH32V20x_EVT.menu.opt.oslto=Smallest (-Os) with LTO
 CH32V20x_EVT.menu.opt.oslto.build.flags.optimize=-Os -flto
 CH32V20x_EVT.menu.opt.o1std=Fast (-O1)
@@ -554,7 +556,7 @@ CH32V20x_EVT.menu.opt.o0std.build.flags.optimize=-O0
 
 # Debug information
 CH32V20x_EVT.menu.dbg.none=None
-CH32V20x_EVT.menu.dbg.none.build.flags.debug=-DNDEBUG 
+CH32V20x_EVT.menu.dbg.none.build.flags.debug=-DNDEBUG
 CH32V20x_EVT.menu.dbg.enable_sym=Symbols Enabled (-g)
 CH32V20x_EVT.menu.dbg.enable_sym.build.flags.debug=-g -DNDEBUG
 CH32V20x_EVT.menu.dbg.enable_log=Core logs Enabled
@@ -578,8 +580,8 @@ CH32V20x_EVT.menu.rtlib.full.build.flags.ldflags=--specs=nosys.specs
 
 
 
-#############################################################################
-##CH32V30x EVT Board   -lprintfloat
+##############################################################################
+##CH32V30x_EVT Board   -lprintfloat, CH32V30x_C: connected product_line  CH32V30x: normal product_line
 
 CH32V30x_EVT.name=CH32V30x
 CH32V30x_EVT.build.core=arduino
@@ -589,7 +591,8 @@ CH32V30x_EVT.upload.maximum_data_size=0
 CH32V30x_EVT.build.variant_h=variant_{build.board}.h
 CH32V30x_EVT.debug.tool=gdb-WCH_LinkE
 
-#CH32V307VCT6 EVT Board    CH32V30x_C: connected product_line  CH32V30x: normal product_line
+
+#CH32V307VCT6 EVT Board
 CH32V30x_EVT.menu.pnum.CH32V307VCT6=CH32V307VCT6 EVT
 CH32V30x_EVT.menu.pnum.CH32V307VCT6.node=NODE_V307VCT6
 CH32V30x_EVT.menu.pnum.CH32V307VCT6.upload.maximum_size=262144
@@ -601,9 +604,9 @@ CH32V30x_EVT.menu.pnum.CH32V307VCT6.build.variant=CH32V30x/CH32V307VCT6
 CH32V30x_EVT.menu.pnum.CH32V307VCT6.build.chip=CH32V30x_C
 CH32V30x_EVT.menu.pnum.CH32V307VCT6.build.march=rv32imafcxw
 CH32V30x_EVT.menu.pnum.CH32V307VCT6.build.mabi=ilp32f
-CH32V30x_EVT.menu.pnum.CH32V307VCT6.build.math_lib_gcc=-lm 
+CH32V30x_EVT.menu.pnum.CH32V307VCT6.build.math_lib_gcc=-lm
 CH32V30x_EVT.menu.pnum.CH32V307VCT6.build.IQ_math_RV32=
-CH32V30x_EVT.menu.pnum.CH32V307VCT6.build.ch_extra_lib=-lprintfloat                           
+CH32V30x_EVT.menu.pnum.CH32V307VCT6.build.ch_extra_lib=-lprintfloat
 
 
 # Upload menu
@@ -613,7 +616,7 @@ CH32V30x_EVT.menu.upload_method.swdMethod.upload.options=
 CH32V30x_EVT.menu.upload_method.swdMethod.upload.tool=WCH_linkE
 
 
-# Clock Select 
+# Clock Select
 CH32V30x_EVT.menu.clock.144MHz_HSI=144MHz Internal
 CH32V30x_EVT.menu.clock.144MHz_HSI.build.flags.clock=-DSYSCLK_FREQ_144MHz_HSI=144000000
 CH32V30x_EVT.menu.clock.120MHz_HSI=120MHz Internal
@@ -646,7 +649,7 @@ CH32V30x_EVT.menu.clock.HSE.build.flags.clock=-DSYSCLK_FREQ_HSE=HSE_VALUE
 
 # Optimizations
 CH32V30x_EVT.menu.opt.osstd=Smallest (-Os default)
-CH32V30x_EVT.menu.opt.osstd.build.flags.optimize=-Os 
+CH32V30x_EVT.menu.opt.osstd.build.flags.optimize=-Os
 CH32V30x_EVT.menu.opt.oslto=Smallest (-Os) with LTO
 CH32V30x_EVT.menu.opt.oslto.build.flags.optimize=-Os -flto
 CH32V30x_EVT.menu.opt.o1std=Fast (-O1)
@@ -669,7 +672,7 @@ CH32V30x_EVT.menu.opt.o0std.build.flags.optimize=-O0
 
 # Debug information
 CH32V30x_EVT.menu.dbg.none=None
-CH32V30x_EVT.menu.dbg.none.build.flags.debug=-DNDEBUG 
+CH32V30x_EVT.menu.dbg.none.build.flags.debug=-DNDEBUG
 CH32V30x_EVT.menu.dbg.enable_sym=Symbols Enabled (-g)
 CH32V30x_EVT.menu.dbg.enable_sym.build.flags.debug=-g -DNDEBUG
 CH32V30x_EVT.menu.dbg.enable_log=Core logs Enabled
@@ -692,8 +695,9 @@ CH32V30x_EVT.menu.rtlib.full.build.flags.ldflags=--specs=nosys.specs
 
 
 
-#############################################################################
-##CH32L10x EVT Board   -lprintf
+
+##############################################################################
+##CH32L10x_EVT Board   -lprintf
 
 CH32L10x_EVT.name=CH32L10x
 CH32L10x_EVT.build.core=arduino
@@ -703,7 +707,8 @@ CH32L10x_EVT.upload.maximum_data_size=0
 CH32L10x_EVT.build.variant_h=variant_{build.board}.h
 CH32L10x_EVT.debug.tool=gdb-WCH_LinkE
 
-#CH32L103C8T6 EVT Board    
+
+#CH32L103C8T6 EVT Board
 CH32L10x_EVT.menu.pnum.CH32L103C8T6=CH32L103C8T6 EVT
 CH32L10x_EVT.menu.pnum.CH32L103C8T6.node=NODE_L103C8T6
 CH32L10x_EVT.menu.pnum.CH32L103C8T6.upload.maximum_size=65536
@@ -715,12 +720,19 @@ CH32L10x_EVT.menu.pnum.CH32L103C8T6.build.variant=CH32L10x/CH32L103C8T6
 CH32L10x_EVT.menu.pnum.CH32L103C8T6.build.chip=CH32L10x
 CH32L10x_EVT.menu.pnum.CH32L103C8T6.build.march=rv32imacxw
 CH32L10x_EVT.menu.pnum.CH32L103C8T6.build.mabi=ilp32
-CH32L10x_EVT.menu.pnum.CH32L103C8T6.build.math_lib_gcc=-lm 
+CH32L10x_EVT.menu.pnum.CH32L103C8T6.build.math_lib_gcc=-lm
 CH32L10x_EVT.menu.pnum.CH32L103C8T6.build.IQ_math_RV32=
-CH32L10x_EVT.menu.pnum.CH32L103C8T6.build.ch_extra_lib=-lprintf     
+CH32L10x_EVT.menu.pnum.CH32L103C8T6.build.ch_extra_lib=-lprintf
 
 
-# Clock Select 
+# Upload menu
+CH32L10x_EVT.menu.upload_method.swdMethod=WCH-SWD
+CH32L10x_EVT.menu.upload_method.swdMethod.upload.protocol=
+CH32L10x_EVT.menu.upload_method.swdMethod.upload.options=
+CH32L10x_EVT.menu.upload_method.swdMethod.upload.tool=WCH_linkE
+
+
+# Clock Select
 CH32L10x_EVT.menu.clock.96MHz_HSI=96MHz Internal
 CH32L10x_EVT.menu.clock.96MHz_HSI.build.flags.clock=-DSYSCLK_FREQ_96MHz_HSI=96000000
 CH32L10x_EVT.menu.clock.72MHz_HSI=72MHz Internal
@@ -731,8 +743,6 @@ CH32L10x_EVT.menu.clock.48MHz_HSI=48MHz Internal
 CH32L10x_EVT.menu.clock.48MHz_HSI.build.flags.clock=-DSYSCLK_FREQ_48MHz_HSI=48000000
 CH32L10x_EVT.menu.clock.HSI=HSI Internal
 CH32L10x_EVT.menu.clock.HSI.build.flags.clock=-DSYSCLK_FREQ_HSI=HSI_VALUE
-CH32L10x_EVT.menu.clock.HSI_LP=HSI_LP Internal
-CH32L10x_EVT.menu.clock.HSI_LP.build.flags.clock=-DSYSCLK_FREQ_HSI_LP=HSI_LP_VALUE
 CH32L10x_EVT.menu.clock.96MHz_HSE=96MHz External
 CH32L10x_EVT.menu.clock.96MHz_HSE.build.flags.clock=-DSYSCLK_FREQ_96MHz_HSE=96000000
 CH32L10x_EVT.menu.clock.72MHz_HSE=72MHz External
@@ -745,17 +755,9 @@ CH32L10x_EVT.menu.clock.HSE=HSE External
 CH32L10x_EVT.menu.clock.HSE.build.flags.clock=-DSYSCLK_FREQ_HSE=HSE_VALUE
 
 
-# Upload menu
-CH32L10x_EVT.menu.upload_method.swdMethod=WCH-SWD
-CH32L10x_EVT.menu.upload_method.swdMethod.upload.protocol=
-CH32L10x_EVT.menu.upload_method.swdMethod.upload.options=
-CH32L10x_EVT.menu.upload_method.swdMethod.upload.tool=WCH_linkE
-
-
-
 # Optimizations
 CH32L10x_EVT.menu.opt.osstd=Smallest (-Os default)
-CH32L10x_EVT.menu.opt.osstd.build.flags.optimize=-Os 
+CH32L10x_EVT.menu.opt.osstd.build.flags.optimize=-Os
 CH32L10x_EVT.menu.opt.oslto=Smallest (-Os) with LTO
 CH32L10x_EVT.menu.opt.oslto.build.flags.optimize=-Os -flto
 CH32L10x_EVT.menu.opt.o1std=Fast (-O1)
@@ -778,7 +780,7 @@ CH32L10x_EVT.menu.opt.o0std.build.flags.optimize=-O0
 
 # Debug information
 CH32L10x_EVT.menu.dbg.none=None
-CH32L10x_EVT.menu.dbg.none.build.flags.debug=-DNDEBUG 
+CH32L10x_EVT.menu.dbg.none.build.flags.debug=-DNDEBUG
 CH32L10x_EVT.menu.dbg.enable_sym=Symbols Enabled (-g)
 CH32L10x_EVT.menu.dbg.enable_sym.build.flags.debug=-g -DNDEBUG
 CH32L10x_EVT.menu.dbg.enable_log=Core logs Enabled
@@ -798,3 +800,4 @@ CH32L10x_EVT.menu.rtlib.nanofps=Newlib Nano + Float Printf/Scanf
 CH32L10x_EVT.menu.rtlib.nanofps.build.flags.ldflags=--specs=nano.specs --specs=nosys.specs -u _printf_float -u _scanf_float
 CH32L10x_EVT.menu.rtlib.full=Newlib Standard
 CH32L10x_EVT.menu.rtlib.full.build.flags.ldflags=--specs=nosys.specs
+

--- a/boards.txt
+++ b/boards.txt
@@ -759,6 +759,8 @@ CH32L10x_EVT.menu.clock.48MHz_HSI=48MHz Internal
 CH32L10x_EVT.menu.clock.48MHz_HSI.build.flags.clock=-DSYSCLK_FREQ_48MHz_HSI=48000000
 CH32L10x_EVT.menu.clock.HSI=HSI Internal
 CH32L10x_EVT.menu.clock.HSI.build.flags.clock=-DSYSCLK_FREQ_HSI=HSI_VALUE
+CH32L10x_EVT.menu.clock.HSI_LP=HSI_LP Internal
+CH32L10x_EVT.menu.clock.HSI_LP.build.flags.clock=-DSYSCLK_FREQ_HSI_LP=HSI_LP_VALUE
 CH32L10x_EVT.menu.clock.96MHz_HSE=96MHz External
 CH32L10x_EVT.menu.clock.96MHz_HSE.build.flags.clock=-DSYSCLK_FREQ_96MHz_HSE=96000000
 CH32L10x_EVT.menu.clock.72MHz_HSE=72MHz External

--- a/boards.txt
+++ b/boards.txt
@@ -617,6 +617,14 @@ CH32V30x_EVT.menu.pnum.CH32V307VCT6.build.IQ_math_RV32=
 CH32V30x_EVT.menu.pnum.CH32V307VCT6.build.ch_extra_lib=-lprintfloat
 
 
+# USB support
+CH32V30x_EVT.menu.usb.none=None
+CH32V30x_EVT.menu.usb.none.build.usb_flags=
+CH32V30x_EVT.menu.usb.tinyusb_usbhs=Adafruit TinyUSB with USBHS
+CH32V30x_EVT.menu.usb.tinyusb_usbhs.build.usb_flags=-DUSBCON -DUSE_TINYUSB -DCFG_TUD_WCH_USBIP_USBHS=1 "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+CH32V30x_EVT.menu.usb.tinyusb_usbfs=Adafruit TinyUSB with USBFS
+CH32V30x_EVT.menu.usb.tinyusb_usbfs.build.usb_flags=-DUSBCON -DUSE_TINYUSB -DCFG_TUD_WCH_USBIP_USBFS=1 "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+
 # Upload menu
 CH32V30x_EVT.menu.upload_method.swdMethod=WCH-SWD
 CH32V30x_EVT.menu.upload_method.swdMethod.upload.protocol=

--- a/cores/arduino/WSerial.h
+++ b/cores/arduino/WSerial.h
@@ -4,6 +4,10 @@
 #include "variant.h"
 #include "HardwareSerial.h"
 
+#if defined(USE_TINYUSB)
+#include "Adafruit_USBD_CDC.h"
+#define Serial SerialTinyUSB
+#endif
 
 #if defined(UART_MODULE_ENABLED) && !defined(UART_MODULE_ONLY)
 

--- a/cores/arduino/main.cpp
+++ b/cores/arduino/main.cpp
@@ -10,11 +10,17 @@
 int main( void )
 {
     pre_init( );
+#if defined(USE_TINYUSB)
+    TinyUSB_Device_Init(0);
+#endif
     setup( );
   
     do {
         loop( );
-      
+#if defined(USE_TINYUSB)
+      TinyUSB_Device_Task();
+      TinyUSB_Device_FlushCDC();
+#endif
     } while (1);
 
     return 0;

--- a/platform.txt
+++ b/platform.txt
@@ -79,7 +79,8 @@ compiler.elf2lst.extra_flags=
 
 # USB Flags
 # ---------
-build.usb_flags=-DUSBCON {build.usb_speed} -DUSBD_VID={build.vid} -DUSBD_PID={build.pid} -DHAL_PCD_MODULE_ENABLED
+#build.usb_flags=-DUSBCON {build.usb_speed} -DUSBD_VID={build.vid} -DUSBD_PID={build.pid} -DHAL_PCD_MODULE_ENABLED
+build.usb_flags=
 
 # Specify defaults for vid/pid, since an empty value is impossible to
 # detect in the preprocessor, but a 0 can be checked for.
@@ -89,7 +90,7 @@ build.pid=0
 
 # Build information's     
 #####################-D{build.board} -DARDUINO_ARCH_{build.arch} -DBOARD_NAME="{build.board}" -DVARIANT_H="{build.variant_h}"
-build.info.flags=-DARDUINO_ARCH_CH32 -D{build.series} -DARDUINO={runtime.ide.version} -D{build.chip} -DVARIANT_H="{build.variant_h}"
+build.info.flags=-DARDUINO_ARCH_CH32 -D{build.series} -DARDUINO={runtime.ide.version} -D{build.chip} -DVARIANT_H="{build.variant_h}" {build.usb_flags}
 
 # Defaults config
 build.xSerial=

--- a/tools/makeboards.py
+++ b/tools/makeboards.py
@@ -11,11 +11,23 @@ mcu_list = {
     'QingKe-V4F': {'march': 'rv32imafcxw', 'mabi': 'ilp32f', 'ch_extra_lib': '-lprintfloat'},
 }
 
+usb_list = {
+    'tinyusb_usbd': {
+        'name': 'Adafruit TinyUSB with USBD',
+        'usb_flags': '-DUSBCON -DUSE_TINYUSB -DCFG_TUD_WCH_USBIP_FSDEV=1 "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"'
+    },
+    'tinyusb_usbfs': {
+        'name': 'Adafruit TinyUSB with USBFS',
+        'usb_flags': '-DUSBCON -DUSE_TINYUSB -DCFG_TUD_WCH_USBIP_USBFS=1 "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"'
+    },
+}
+
 # series: name, pnums
 board_list = {
     'CH32V00x': {
         'name': 'CH32V00x_EVT',
         'info': '',
+        'usb': [],
         'hsi': [48, 24, 8],
         'hse': [48, 24, 8],
         'pnums': {
@@ -25,6 +37,7 @@ board_list = {
     'CH32VM00X': {
         'name': 'CH32VM00X_EVT',
         'info': 'including V/M 002 004 005 006 007',
+        'usb': [],
         'hsi': [48, 24, 8],
         'hse': [48, 24, 8],
         'pnums': {
@@ -34,6 +47,7 @@ board_list = {
     'CH32X035': {
         'name': 'CH32X035_EVT',
         'info': '',
+        'usb': [],
         'hsi': [48, 24, 16, 12, 8],
         'hse': [],
         'pnums': {
@@ -43,6 +57,7 @@ board_list = {
     'CH32V10x': {
         'name': 'CH32V10x_EVT',
         'info': '-lprintf, CH32V10x_3V3: 3.3V power supply  CH32V10x_5V: 5V power supply',
+        'usb': [],
         'hsi': [72, 56, 48, 8],
         'hse': [72, 56, 48, 8],
         'pnums': {
@@ -52,6 +67,7 @@ board_list = {
     'CH32V20x': {
         'name': 'CH32V20x_EVT',
         'info': '',
+        'usb': ['tinyusb_usbd', 'tinyusb_usbfs'],
         'hsi': [144, 120, 96, 72, 56, 48, 0],
         'hse': [144, 120, 96, 72, 56, 48, 0],
         'pnums': {
@@ -64,6 +80,7 @@ board_list = {
     'CH32V30x': {
         'name': 'CH32V30x_EVT',
         'info': '-lprintfloat, CH32V30x_C: connected product_line  CH32V30x: normal product_line',
+        'usb': [],
         'hsi': [144, 120, 96, 72, 56, 48, 0],
         'hse': [144, 120, 96, 72, 56, 48, 0],
         'pnums': {
@@ -73,6 +90,7 @@ board_list = {
     'CH32L10x': {
         'name': 'CH32L10x_EVT',
         'info': '-lprintf',
+        'usb': [],
         'hsi': [96, 72, 56, 48, 0],
         'hse': [96, 72, 56, 48, 0],
         'pnums': {
@@ -137,6 +155,20 @@ def build_pnum(series, values):
         print(f'{menu}.build.IQ_math_RV32=')
         print(f'{menu}.build.ch_extra_lib={mcu_list[mcu]["ch_extra_lib"]}')
         print()
+
+
+def build_usb(series, values):
+    if len(values['usb']) == 0:
+        return
+    print()
+    print("# USB support")
+    name = values["name"]
+    menu = f'{name}.menu.usb'
+    print(f'{menu}.none=None')
+    print(f'{menu}.none.build.usb_flags=')
+    for usb in values['usb']:
+        print(f'{menu}.{usb}={usb_list[usb]["name"]}')
+        print(f'{menu}.{usb}.build.usb_flags={usb_list[usb]["usb_flags"]}')
 
 
 def build_upload(series, values):
@@ -243,6 +275,7 @@ def build_runtimelib(series, values):
 def make_board(series, values):
     build_header(series, values)
     build_pnum(series, values)
+    build_usb(series, values)
     build_upload(series, values)
     build_clock(series, values)
     build_optimization(series, values)

--- a/tools/makeboards.py
+++ b/tools/makeboards.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+
+
+# mcu: march, mabi, math_lib_gcc, IQ_math_RV32, ch_extra_lib
+mcu_list = {
+    'QingKe-V2A': {'march': 'rv32ecxw', 'mabi': 'ilp32e', 'ch_extra_lib': '-lprintf'},
+    'QingKe-V2C': {'march': 'rv32ecxw', 'mabi': 'ilp32e', 'ch_extra_lib': '-lprintf'},
+    'QingKe-V3A': {'march': 'rv32imac', 'mabi': 'ilp32', 'ch_extra_lib': '-lprintf'},
+    'QingKe-V4B': {'march': 'rv32imacxw', 'mabi': 'ilp32', 'ch_extra_lib': '-lprintf'},
+    'QingKe-V4C': {'march': 'rv32imacxw', 'mabi': 'ilp32', 'ch_extra_lib': '-lprintf'},
+    'QingKe-V4F': {'march': 'rv32imafcxw', 'mabi': 'ilp32f', 'ch_extra_lib': '-lprintfloat'},
+}
+
+# series: name, pnums
+board_list = {
+    'CH32V00x': {
+        'name': 'CH32V00x_EVT',
+        'info': '',
+        'hsi': [48, 24, 8],
+        'hse': [48, 24, 8],
+        'pnums': {
+            'CH32V003F4': {'name': 'CH32V003F4 EVT', 'maximum_size': 16384, 'maximum_data_size': 2048, 'mcu': 'QingKe-V2A', 'chip': 'CH32V003F4'},
+        }
+    },
+    'CH32VM00X': {
+        'name': 'CH32VM00X_EVT',
+        'info': 'including V/M 002 004 005 006 007',
+        'hsi': [48, 24, 8],
+        'hse': [48, 24, 8],
+        'pnums': {
+            'CH32V006K8': {'name': 'CH32V006K8 EVT', 'maximum_size': 63488, 'maximum_data_size': 8192, 'mcu': 'QingKe-V2C', 'chip': 'CH32V006K8'},
+        }
+    },
+    'CH32X035': {
+        'name': 'CH32X035_EVT',
+        'info': '',
+        'hsi': [48, 24, 16, 12, 8],
+        'hse': [],
+        'pnums': {
+            'CH32X035G8U': {'name': 'CH32X035G8U EVT', 'maximum_size': 63488, 'maximum_data_size': 20480, 'mcu': 'QingKe-V4C', 'chip': 'CH32X035G8U'},
+        }
+    },
+    'CH32V10x': {
+        'name': 'CH32V10x_EVT',
+        'info': '-lprintf, CH32V10x_3V3: 3.3V power supply  CH32V10x_5V: 5V power supply',
+        'hsi': [72, 56, 48, 8],
+        'hse': [72, 56, 48, 8],
+        'pnums': {
+            'CH32V103R8T6': {'name': 'CH32V103R8T6 EVT', 'maximum_size': 65536, 'maximum_data_size': 20480, 'mcu': 'QingKe-V3A', 'chip': 'CH32V10x_3V3'},
+        }
+    },
+    'CH32V20x': {
+        'name': 'CH32V20x_EVT',
+        'info': '',
+        'hsi': [144, 120, 96, 72, 56, 48, 0],
+        'hse': [144, 120, 96, 72, 56, 48, 0],
+        'pnums': {
+            'CH32V203RB': {'name': 'CH32V203RB EVT', 'maximum_size': 131072, 'maximum_data_size': 65536, 'mcu': 'QingKe-V4C', 'chip': 'CH32V203'},
+            'CH32V203G8': {'name': 'CH32V203G8 EVT', 'maximum_size': 65536, 'maximum_data_size': 20480, 'mcu': 'QingKe-V4B', 'chip': 'CH32V203'},
+            'CH32V203C8': {'name': 'CH32V203C8', 'maximum_size': 65536, 'maximum_data_size': 20480, 'mcu': 'QingKe-V4B', 'chip': 'CH32V203'},
+            'CH32V203C6': {'name': 'CH32V203C6', 'maximum_size': 32768, 'maximum_data_size': 20480, 'mcu': 'QingKe-V4B', 'chip': 'CH32V203'},
+        }
+    },
+    'CH32V30x': {
+        'name': 'CH32V30x_EVT',
+        'info': '-lprintfloat, CH32V30x_C: connected product_line  CH32V30x: normal product_line',
+        'hsi': [144, 120, 96, 72, 56, 48, 0],
+        'hse': [144, 120, 96, 72, 56, 48, 0],
+        'pnums': {
+            'CH32V307VCT6': {'name': 'CH32V307VCT6 EVT', 'maximum_size': 262144, 'maximum_data_size': 65536, 'mcu': 'QingKe-V4F', 'chip': 'CH32V30x_C'},
+        }
+    },
+    'CH32L10x': {
+        'name': 'CH32L10x_EVT',
+        'info': '-lprintf',
+        'hsi': [96, 72, 56, 48, 0],
+        'hse': [96, 72, 56, 48, 0],
+        'pnums': {
+            'CH32L103C8T6': {'name': 'CH32L103C8T6 EVT', 'maximum_size': 65536, 'maximum_data_size': 20480, 'mcu': 'QingKe-V4C', 'chip': 'CH32L10x'},
+        }
+    }
+}
+
+
+def build_global_menu():
+    print("""# See: https://arduino.github.io/arduino-cli/latest/platform-specification/
+
+menu.pnum=Board Select
+menu.clock=Clock Select
+menu.xserial=U(S)ART support
+menu.usb=USB support (if available)
+menu.xusb=USB speed (if available)
+menu.virtio=Virtual serial support
+
+menu.opt=Optimize
+menu.dbg=Debug symbols and core logs
+menu.rtlib=C Runtime Library
+menu.upload_method=Upload method""")
+
+
+def build_header(series, values):
+    print()
+    print()
+    print()
+    print('#'*78)
+    name = values["name"]
+    print(f'##{name} Board   {values["info"]}')
+    print()
+    print(f'{name}.name={series}')
+    print(f'{name}.build.core=arduino')
+    print(f'{name}.build.board={name}')
+    print(f'{name}.upload.maximum_size=0')
+    print(f'{name}.upload.maximum_data_size=0')
+    print(f'{name}.build.variant_h=variant_{{build.board}}.h')
+    print(f'{name}.debug.tool=gdb-WCH_LinkE')
+    print()
+
+
+def build_pnum(series, values):
+    print()
+    for p, pv in values['pnums'].items():
+        menu = f'{values["name"]}.menu.pnum.{p}'
+        mcu = pv["mcu"]
+        print(f'#{pv["name"]} Board')
+        print(f'{menu}={pv["name"]}')
+        print(f'{menu}.node={p.replace("CH32", "NODE_")}')
+        print(f'{menu}.upload.maximum_size={pv["maximum_size"]}')
+        print(f'{menu}.upload.maximum_data_size={pv["maximum_data_size"]}')
+        print(f'{menu}.build.mcu={mcu}')
+        print(f'{menu}.build.board={p}')
+        print(f'{menu}.build.series={series}')
+        print(f'{menu}.build.variant={series}/{p}')
+        print(f'{menu}.build.chip={pv["chip"]}')
+        print(f'{menu}.build.march={mcu_list[mcu]["march"]}')
+        print(f'{menu}.build.mabi={mcu_list[mcu]["mabi"]}')
+        print(f'{menu}.build.math_lib_gcc=-lm')
+        print(f'{menu}.build.IQ_math_RV32=')
+        print(f'{menu}.build.ch_extra_lib={mcu_list[mcu]["ch_extra_lib"]}')
+        print()
+
+
+def build_upload(series, values):
+    print()
+    print("# Upload menu")
+    name = values["name"]
+    menu = f'{name}.menu.upload_method'
+    print(f'{menu}.swdMethod=WCH-SWD')
+    print(f'{menu}.swdMethod.upload.protocol=')
+    print(f'{menu}.swdMethod.upload.options=')
+    print(f'{menu}.swdMethod.upload.tool=WCH_linkE')
+    print()
+
+
+def build_optimization(series, values):
+    print()
+    print("# Optimizations")
+    name = values["name"]
+    menu = f'{name}.menu.opt'
+
+    print(f'{menu}.osstd=Smallest (-Os default)')
+    print(f'{menu}.osstd.build.flags.optimize=-Os')
+    print(f'{menu}.oslto=Smallest (-Os) with LTO')
+    print(f'{menu}.oslto.build.flags.optimize=-Os -flto')
+
+    print(f'{menu}.o1std=Fast (-O1)')
+    print(f'{menu}.o1std.build.flags.optimize=-O1')
+    print(f'{menu}.o1lto=Fast (-O1) with LTO')
+    print(f'{menu}.o1lto.build.flags.optimize=-O1 -flto')
+
+    print(f'{menu}.o2std=Faster (-O2)')
+    print(f'{menu}.o2std.build.flags.optimize=-O2')
+    print(f'{menu}.o2lto=Faster (-O2) with LTO')
+    print(f'{menu}.o2lto.build.flags.optimize=-O2 -flto')
+
+    print(f'{menu}.o3std=Fastest (-O3)')
+    print(f'{menu}.o3std.build.flags.optimize=-O3')
+    print(f'{menu}.o3lto=Fastest (-O3) with LTO')
+    print(f'{menu}.o3lto.build.flags.optimize=-O3 -flto')
+
+    print(f'{menu}.ogstd=Debug (-Og)')
+    print(f'{menu}.ogstd.build.flags.optimize=-Og')
+    print(f'{menu}.o0std=No Optimization (-O0)')
+    print(f'{menu}.o0std.build.flags.optimize=-O0')
+    print()
+
+
+def build_clock(series, values):
+    print()
+    print("# Clock Select")
+    name = values["name"]
+    menu = f'{name}.menu.clock'
+    for hsi in values['hsi']:
+        if hsi == 0:
+            print(f'{menu}.HSI=HSI Internal')
+            print(f'{menu}.HSI.build.flags.clock=-DSYSCLK_FREQ_HSI=HSI_VALUE')
+        else:
+            print(f'{menu}.{hsi}MHz_HSI={hsi}MHz Internal')
+            print(f'{menu}.{hsi}MHz_HSI.build.flags.clock=-DSYSCLK_FREQ_{hsi}MHz_HSI={hsi}000000')
+    for hse in values['hse']:
+        if hse == 0:
+            print(f'{menu}.HSE=HSE External')
+            print(f'{menu}.HSE.build.flags.clock=-DSYSCLK_FREQ_HSE=HSE_VALUE')
+        else:
+            print(f'{menu}.{hse}MHz_HSE={hse}MHz External')
+            print(f'{menu}.{hse}MHz_HSE.build.flags.clock=-DSYSCLK_FREQ_{hse}MHz_HSE={hse}000000')
+    print()
+
+
+def build_debug(series, values):
+    print()
+    print("# Debug information")
+    name = values["name"]
+    menu = f'{name}.menu.dbg'
+    print(f'{menu}.none=None')
+    print(f'{menu}.none.build.flags.debug=-DNDEBUG')
+    print(f'{menu}.enable_sym=Symbols Enabled (-g)')
+    print(f'{menu}.enable_sym.build.flags.debug=-g -DNDEBUG')
+    print(f'{menu}.enable_log=Core logs Enabled')
+    print(f'{menu}.enable_log.build.flags.debug=')
+    print(f'{menu}.enable_all=Core Logs and Symbols Enabled (-g)')
+    print(f'{menu}.enable_all.build.flags.debug=-g')
+    print()
+
+
+def build_runtimelib(series, values):
+    print()
+    print("# C Runtime Library")
+    name = values["name"]
+    menu = f'{name}.menu.rtlib'
+    print(f'{menu}.nano=Newlib Nano (default)')
+    print(f'{menu}.nano.build.flags.ldflags=--specs=nano.specs --specs=nosys.specs')
+    print(f'{menu}.nanofp=Newlib Nano + Float Printf')
+    print(f'{menu}.nanofp.build.flags.ldflags=--specs=nano.specs --specs=nosys.specs -u _printf_float')
+    print(f'{menu}.nanofs=Newlib Nano + Float Scanf')
+    print(f'{menu}.nanofs.build.flags.ldflags=--specs=nano.specs --specs=nosys.specs -u _scanf_float')
+    print(f'{menu}.nanofps=Newlib Nano + Float Printf/Scanf')
+    print(f'{menu}.nanofps.build.flags.ldflags=--specs=nano.specs --specs=nosys.specs -u _printf_float -u _scanf_float')
+    print(f'{menu}.full=Newlib Standard')
+    print(f'{menu}.full.build.flags.ldflags=--specs=nosys.specs')
+    print()
+
+
+def make_board(series, values):
+    build_header(series, values)
+    build_pnum(series, values)
+    build_upload(series, values)
+    build_clock(series, values)
+    build_optimization(series, values)
+    build_debug(series, values)
+    build_runtimelib(series, values)
+
+# ------------------------------
+# main
+# ------------------------------
+build_global_menu()
+
+for k, v in board_list.items():
+    make_board(k, v)

--- a/tools/makeboards.py
+++ b/tools/makeboards.py
@@ -95,7 +95,7 @@ board_list = {
         'name': 'CH32L10x_EVT',
         'info': '-lprintf',
         'usb': [],
-        'hsi': [96, 72, 56, 48, 0],
+        'hsi': [96, 72, 56, 48, 0, 'HSI_LP'],
         'hse': [96, 72, 56, 48, 0],
         'pnums': {
             'CH32L103C8T6': {'name': 'CH32L103C8T6 EVT', 'maximum_size': 65536, 'maximum_data_size': 20480, 'mcu': 'QingKe-V4C', 'chip': 'CH32L10x'},
@@ -229,6 +229,9 @@ def build_clock(series, values):
         if hsi == 0:
             print(f'{menu}.HSI=HSI Internal')
             print(f'{menu}.HSI.build.flags.clock=-DSYSCLK_FREQ_HSI=HSI_VALUE')
+        elif hsi == 'HSI_LP':
+            print(f'{menu}.HSI_LP=HSI_LP Internal')
+            print(f'{menu}.HSI_LP.build.flags.clock=-DSYSCLK_FREQ_HSI_LP=HSI_LP_VALUE')
         else:
             print(f'{menu}.{hsi}MHz_HSI={hsi}MHz Internal')
             print(f'{menu}.{hsi}MHz_HSI.build.flags.clock=-DSYSCLK_FREQ_{hsi}MHz_HSI={hsi}000000')

--- a/tools/makeboards.py
+++ b/tools/makeboards.py
@@ -20,6 +20,10 @@ usb_list = {
         'name': 'Adafruit TinyUSB with USBFS',
         'usb_flags': '-DUSBCON -DUSE_TINYUSB -DCFG_TUD_WCH_USBIP_USBFS=1 "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"'
     },
+    'tinyusb_usbhs': {
+        'name': 'Adafruit TinyUSB with USBHS',
+        'usb_flags': '-DUSBCON -DUSE_TINYUSB -DCFG_TUD_WCH_USBIP_USBHS=1 "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"'
+    },
 }
 
 # series: name, pnums
@@ -80,7 +84,7 @@ board_list = {
     'CH32V30x': {
         'name': 'CH32V30x_EVT',
         'info': '-lprintfloat, CH32V30x_C: connected product_line  CH32V30x: normal product_line',
-        'usb': [],
+        'usb': ['tinyusb_usbhs', 'tinyusb_usbfs'],
         'hsi': [144, 120, 96, 72, 56, 48, 0],
         'hse': [144, 120, 96, 72, 56, 48, 0],
         'pnums': {


### PR DESCRIPTION
This PR add TinyUSB library support for ch32 core with minimal changes as possible. These are tested and worked with Ch32v203 with both USBD and USBFS, and ch32v307 both USBFS and USBHS (need 144Mhz HSE since I am familliar with highspeed clock setup).
- add TinyUSB to `libraries/` as submodules, this is required for having Serial to include and declare as USB virtual come instead of UART. (this require git submodule update --init), and the zip package should also clone this for a new core release
- Add Menu selection for TinyUSB with: None (default), TinyUSB with USBD, USBFS, USBHS. Therefore by default, this should not affect existing code, in the future if you guys want to add your own usb driver, we can just add another entry to the menu for user to select.
- To make it easier to add new boards and usb menu to boards.txt, I have written tools/makeboards.py (this is how we manage boards in Adafruit repo), this help to ease the new boards addition, and fix typo issue, just update the script then run `python tools/makeboards.py > boards.txt`. It does catch some of your existing typo, please let us know if this looks good to you. Otherwise we can skip this, and just copy/paste & modify manually. 
- If TinyUSB is selected: main() will call TinyUSB_Device_Init() before setup() and task()/cdc flush() in the loop. This ease user from manually calling these to handle usb communication.
- WSerial.h include tinyusb header and define Serial as TinyUSB's virtual com if selected

Ch32v203: only USBD and USBFS are available
![image](https://github.com/openwch/arduino_core_ch32/assets/249515/2b08f369-994e-4dc2-96a7-7990210b7e8b)

Ch32v307: only USBFS and USBHS are available
![Screenshot from 2024-06-17 11-33-55](https://github.com/openwch/arduino_core_ch32/assets/249515/ed52cc67-346a-4557-83f0-3a9c5617de1f)

Limitation:
- ch32v307 usb highspeed only work when compiling with HSE (144mhz), I tried with HSI but it does not work, this is probably due to usbhs clock setup. I am not too familliar with this, if possible, pleaes help us out with this https://github.com/adafruit/Adafruit_TinyUSB_Arduino/blob/ch32-core-support/src/arduino/ports/ch32/Adafruit_TinyUSB_ch32.cpp#L157
- ch32v103 isn't working, I have no idea why, I tried to add it to tinyusb core, but it doesnn't work there as well. Any helps is appreciated https://github.com/adafruit/Adafruit_TinyUSB_Arduino/blob/ch32-core-support/src/arduino/ports/ch32/Adafruit_TinyUSB_ch32.cpp#L110, https://github.com/hathach/tinyusb/pull/2674

Note: this uses https://github.com/adafruit/Adafruit_TinyUSB_Arduino/pull/429, once this PR is approved and merged, we will release a new version for tinyusb and make an following up PR so that this core use an official new release.

@ladyada