### PR TITLE
add upload via wchisp tool

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -48,6 +48,10 @@ CH32V00x_EVT.menu.upload_method.swdMethod=WCH-SWD
 CH32V00x_EVT.menu.upload_method.swdMethod.upload.protocol=
 CH32V00x_EVT.menu.upload_method.swdMethod.upload.options=
 CH32V00x_EVT.menu.upload_method.swdMethod.upload.tool=WCH_linkE
+CH32V00x_EVT.menu.upload_method.ispMethod=WCH-ISP
+CH32V00x_EVT.menu.upload_method.ispMethod.upload.protocol=
+CH32V00x_EVT.menu.upload_method.ispMethod.upload.options=
+CH32V00x_EVT.menu.upload_method.ispMethod.upload.tool=wchisp
 
 
 # Clock Select
@@ -148,6 +152,10 @@ CH32VM00X_EVT.menu.upload_method.swdMethod=WCH-SWD
 CH32VM00X_EVT.menu.upload_method.swdMethod.upload.protocol=
 CH32VM00X_EVT.menu.upload_method.swdMethod.upload.options=
 CH32VM00X_EVT.menu.upload_method.swdMethod.upload.tool=WCH_linkE
+CH32VM00X_EVT.menu.upload_method.ispMethod=WCH-ISP
+CH32VM00X_EVT.menu.upload_method.ispMethod.upload.protocol=
+CH32VM00X_EVT.menu.upload_method.ispMethod.upload.options=
+CH32VM00X_EVT.menu.upload_method.ispMethod.upload.tool=wchisp
 
 
 # Clock Select
@@ -248,6 +256,10 @@ CH32X035_EVT.menu.upload_method.swdMethod=WCH-SWD
 CH32X035_EVT.menu.upload_method.swdMethod.upload.protocol=
 CH32X035_EVT.menu.upload_method.swdMethod.upload.options=
 CH32X035_EVT.menu.upload_method.swdMethod.upload.tool=WCH_linkE
+CH32X035_EVT.menu.upload_method.ispMethod=WCH-ISP
+CH32X035_EVT.menu.upload_method.ispMethod.upload.protocol=
+CH32X035_EVT.menu.upload_method.ispMethod.upload.options=
+CH32X035_EVT.menu.upload_method.ispMethod.upload.tool=wchisp
 
 
 # Clock Select
@@ -346,6 +358,10 @@ CH32V10x_EVT.menu.upload_method.swdMethod=WCH-SWD
 CH32V10x_EVT.menu.upload_method.swdMethod.upload.protocol=
 CH32V10x_EVT.menu.upload_method.swdMethod.upload.options=
 CH32V10x_EVT.menu.upload_method.swdMethod.upload.tool=WCH_linkE
+CH32V10x_EVT.menu.upload_method.ispMethod=WCH-ISP
+CH32V10x_EVT.menu.upload_method.ispMethod.upload.protocol=
+CH32V10x_EVT.menu.upload_method.ispMethod.upload.options=
+CH32V10x_EVT.menu.upload_method.ispMethod.upload.tool=wchisp
 
 
 # Clock Select
@@ -522,6 +538,10 @@ CH32V20x_EVT.menu.upload_method.swdMethod=WCH-SWD
 CH32V20x_EVT.menu.upload_method.swdMethod.upload.protocol=
 CH32V20x_EVT.menu.upload_method.swdMethod.upload.options=
 CH32V20x_EVT.menu.upload_method.swdMethod.upload.tool=WCH_linkE
+CH32V20x_EVT.menu.upload_method.ispMethod=WCH-ISP
+CH32V20x_EVT.menu.upload_method.ispMethod.upload.protocol=
+CH32V20x_EVT.menu.upload_method.ispMethod.upload.options=
+CH32V20x_EVT.menu.upload_method.ispMethod.upload.tool=wchisp
 
 
 # Clock Select
@@ -646,6 +666,10 @@ CH32V30x_EVT.menu.upload_method.swdMethod=WCH-SWD
 CH32V30x_EVT.menu.upload_method.swdMethod.upload.protocol=
 CH32V30x_EVT.menu.upload_method.swdMethod.upload.options=
 CH32V30x_EVT.menu.upload_method.swdMethod.upload.tool=WCH_linkE
+CH32V30x_EVT.menu.upload_method.ispMethod=WCH-ISP
+CH32V30x_EVT.menu.upload_method.ispMethod.upload.protocol=
+CH32V30x_EVT.menu.upload_method.ispMethod.upload.options=
+CH32V30x_EVT.menu.upload_method.ispMethod.upload.tool=wchisp
 
 
 # Clock Select
@@ -762,6 +786,10 @@ CH32L10x_EVT.menu.upload_method.swdMethod=WCH-SWD
 CH32L10x_EVT.menu.upload_method.swdMethod.upload.protocol=
 CH32L10x_EVT.menu.upload_method.swdMethod.upload.options=
 CH32L10x_EVT.menu.upload_method.swdMethod.upload.tool=WCH_linkE
+CH32L10x_EVT.menu.upload_method.ispMethod=WCH-ISP
+CH32L10x_EVT.menu.upload_method.ispMethod.upload.protocol=
+CH32L10x_EVT.menu.upload_method.ispMethod.upload.options=
+CH32L10x_EVT.menu.upload_method.ispMethod.upload.tool=wchisp
 
 
 # Clock Select

--- a/platform.txt
+++ b/platform.txt
@@ -169,8 +169,15 @@ tools.WCH_linkE.upload.params.quiet=
 tools.WCH_linkE.upload.config={runtime.tools.openocd.path}/bin/wch-riscv.cfg
 tools.WCH_linkE.upload.pattern="{path}{cmd}" -f "{upload.config}" -c init -c halt -c "program {{build.path}/{build.project_name}.elf} verify; wlink_reset_resume; exit;"
 
-
 #tools.WCH_linkE.upload.pattern="{path}{cmd}" -f {upload.config} -c init -c halt -c "program {{build.path}/{build.project_name}.elf}; verify_image {{build.path}/{build.project_name}.elf}; wlink_reset_resume;  exit;"
+
+
+## WCH-ISP
+tools.wchisp.path={runtime.tools.wchisp.path}/
+tools.wchisp.cmd=wchisp
+tools.wchisp.upload.params.verbose=
+tools.wchisp.upload.params.quiet=
+tools.wchisp.upload.pattern="{path}{cmd}" {upload.verbose} flash "{build.path}/{build.project_name}.elf"
 
 
 # Debugger configuration (general options)

--- a/tools/makeboards.py
+++ b/tools/makeboards.py
@@ -181,10 +181,19 @@ def build_upload(series, values):
     print("# Upload menu")
     name = values["name"]
     menu = f'{name}.menu.upload_method'
-    print(f'{menu}.swdMethod=WCH-SWD')
-    print(f'{menu}.swdMethod.upload.protocol=')
-    print(f'{menu}.swdMethod.upload.options=')
-    print(f'{menu}.swdMethod.upload.tool=WCH_linkE')
+
+    menu_swd = f'{menu}.swdMethod'
+    print(f'{menu_swd}=WCH-SWD')
+    print(f'{menu_swd}.upload.protocol=')
+    print(f'{menu_swd}.upload.options=')
+    print(f'{menu_swd}.upload.tool=WCH_linkE')
+
+    menu_isp = f'{menu}.ispMethod'
+    print(f'{menu_isp}=WCH-ISP')
+    print(f'{menu_isp}.upload.protocol=')
+    print(f'{menu_isp}.upload.options=')
+    print(f'{menu_isp}.upload.tool=wchisp')
+
     print()
 
 


### PR DESCRIPTION
**PR Description**

This PR add [wchisp](https://github.com/ch32-rs/wchisp) as additional upload method with ch32 bootrom. This is nice to have since not all user has wlinke, and not all boards exposing SWD/SCLK for programming. For now, there is no auto-reset to bootrom just yet, user need to manually hold BOOT0 High when reset.

**How to test**

- Apply this PR changes
- download wchisp v0.2.3 binaries from https://github.com/ch32-rs/wchisp/releases/tag/v0.2.3 according to your OS
- extract executable binaries to your arduino15 tool folder e.g  `/home/user/.arduino15/packages/WCH/tools/wchisp/0.2.3/wchisp`
- Reload arduino, select Tools->Upload method->WCH-ISP
- HOLD BOOT0 to High, and reset to put board into bootrom
- click upload

Note: for windows, you need to use zadig to change the driver to winUSB, on Linux udev rule for bootloader vid/pid should be added. Following is the flashing log on my linux machine.

**This tool is tested and able to flash ch32v203g6 mcu on both Linux and Windows**. It should work with all mcu that is supported by wchisp https://github.com/ch32-rs/wchisp?tab=readme-ov-file#tested-on

![Screenshot from 2024-06-27 17-35-11](https://github.com/openwch/arduino_core_ch32/assets/249515/1e6b19d3-0384-49df-a854-99321452500a)


```
/home/hathach/.arduino15/packages/WCH/tools/wchisp/0.2.3/wchisp flash /tmp/arduino_build_394713/blinky.ino.elf 
10:18:03 [INFO] Chip: CH32V203G6U6[0x3619] (Code Flash: 32KiB)
10:18:03 [INFO] Chip UID: CD-AB-15-41-13-BC-F5-A8
10:18:03 [INFO] BTVER(bootloader ver): 02.70
10:18:03 [INFO] Code Flash protected: false
10:18:03 [INFO] Current config registers: a55a3fc000ff00ffffffffff00020700cdab154113bcf5a8
RDPR_USER: 0xC03F5AA5
  [7:0]   RDPR 0xA5 (0b10100101)
    `- Unprotected
  [16:16] IWDG_SW 0x1 (0b1)
    `- IWDG enabled by the software, and disabled by hardware
  [17:17] STOP_RST 0x1 (0b1)
    `- Disable
  [18:18] STANDBY_RST 0x1 (0b1)
    `- Disable, entering standby-mode without RST
  [23:22] SRAM_CODE_MODE 0x0 (0b0)
    `- CODE-192KB + RAM-128KB / CODE-128KB + RAM-64KB depending on the chip
DATA: 0xFF00FF00
  [7:0]   DATA0 0x0 (0b0)
  [23:16] DATA1 0x0 (0b0)
WRP: 0xFFFFFFFF
  `- Unprotected
10:18:03 [INFO] Read /tmp/arduino_build_394713/blinky.ino.elf as ELF format
10:18:03 [INFO] Found loadable segment, physical address: 0x00000000, virtual address: 0x00000000, flags: 0x7
10:18:03 [INFO] Section names: [".init", ".vector", ".text", ".init_array"]
10:18:03 [INFO] Found loadable segment, physical address: 0x00007c88, virtual address: 0x20000000, flags: 0x6
10:18:03 [INFO] Section names: [".data"]
10:18:03 [INFO] Firmware size: 32768
10:18:03 [INFO] Erasing...
10:18:03 [INFO] Erased 33 code flash sectors
10:18:04 [INFO] Erase done
10:18:04 [INFO] Writing to code flash...
10:18:05 [INFO] Code flash 32768 bytes written
10:18:05 [INFO] Verifying...
10:18:05 [INFO] Verify OK
10:18:05 [INFO] Now reset device and skip any communication errors
10:18:05 [INFO] Device reset
```

@ladyada