### PR TITLE
fix reboot trap when missing Adafruit_TinyUSB.h header

### DIFF
--- a/cores/arduino/main.cpp
+++ b/cores/arduino/main.cpp
@@ -11,15 +11,21 @@ int main( void )
 {
     pre_init( );
 #if defined(USE_TINYUSB)
-    TinyUSB_Device_Init(0);
+    if (TinyUSB_Device_Init) {
+        TinyUSB_Device_Init(0);
+    }
 #endif
     setup( );
   
     do {
         loop( );
 #if defined(USE_TINYUSB)
-      TinyUSB_Device_Task();
-      TinyUSB_Device_FlushCDC();
+        if (TinyUSB_Device_Task) {
+            TinyUSB_Device_Task();
+        }
+        if (TinyUSB_Device_FlushCDC) {
+            TinyUSB_Device_FlushCDC();
+        }
 #endif
     } while (1);
 


### PR DESCRIPTION
This PR fix issue when TinyUSB is selected in the USB Menu, but the sketch does not include `Adafruit_TinyUSB.h`. 

Root cause: when missing header, arduino does not compile and link the sketch with tinyusb library --> which result to have TinyUSB_Device_Init/TinyUSB_Device_Task/TinyUSB_Device_FlushCDC is NULL. Calling these is essential jumping to addr0 i.e reset constantly.

Found by @ladyada when testing qtpy v203 board.

```C++
#include <Arduino.h>
// #include <Adafruit_TinyUSB.h> <-- missing this cause hardfault

const int led_pin = A0;

void setup () {
  pinMode(led_pin, OUTPUT);
}

void loop () {
  digitalWrite(led_pin, HIGH);   // turn the LED on (HIGH is the voltage level)
  delay(1000);                       // wait for a second
  digitalWrite(led_pin, LOW);    // turn the LED off by making the voltage LOW
  delay(1000);                       // wait for a second
}
```