### PR TITLE
Clarify CH32 core name in installation directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add the following link in the "*Additional Boards Managers URLs*" field:
 
 https://github.com/openwch/board_manager_files/raw/main/package_ch32v_index.json
 
-Then you can search for "**wch**" through the "**board manager**", find the installation package, and install it.
+Then you can search for "**CH32**" through the "**Boards Manager**", find the "**CH32 MCU EVT Boards**" core, and install it.
 
 ## Supported boards
 


### PR DESCRIPTION
Trivial documentation change which may help prevent more folks getting confused and logging issues like https://github.com/openwch/arduino_core_ch32/issues/130 and https://github.com/openwch/arduino_core_ch32/issues/117