### PR TITLE
USB PD: Improve requesting fixed voltage function

### DIFF
--- a/libraries/USBPD_SINK/examples/usbpd_sink_request_voltage/usbpd_sink_request_voltage.ino
+++ b/libraries/USBPD_SINK/examples/usbpd_sink_request_voltage/usbpd_sink_request_voltage.ino
@@ -20,7 +20,10 @@ void loop() {
 
     if(usbpd_sink_get_ready())
     {
-        usbpd_sink_set_request_fixed_voltage(setVoltage);
+        if(usbpd_sink_set_request_fixed_voltage(setVoltage) == false)
+        {
+            Serial.printf("unsupported voltage\r\n");
+        }
     }
 
 // button, myIndex++

--- a/libraries/USBPD_SINK/src/usbpd_sink.c
+++ b/libraries/USBPD_SINK/src/usbpd_sink.c
@@ -38,7 +38,7 @@ void usbpd_sink_clear_ready(void)
     pdControl_g.cc_USBPD_READY = 0;
 }
 
-void usbpd_sink_set_request_fixed_voltage(Request_voltage_t requestVoltage)
+bool usbpd_sink_set_request_fixed_voltage(Request_voltage_t requestVoltage)
 {
     uint16_t targetVoltage;
     switch (requestVoltage)
@@ -73,11 +73,12 @@ void usbpd_sink_set_request_fixed_voltage(Request_voltage_t requestVoltage)
         if(pdControl_g.cc_FixedSourceCap[i].Voltage == targetVoltage)
         { 
             pdControl_g.cc_SetPDONum = i+1;
-            return;
+            return true;
         }
     }
-    pdControl_g.cc_SetPDONum = (pdControl_g.cc_SourcePDONum - pdControl_g.cc_SourcePPSNum);
     
+    // unsupported voltage
+    return false;
 }
 
 void timer3_init(uint16_t arr, uint16_t psc)

--- a/libraries/USBPD_SINK/src/usbpd_sink.h
+++ b/libraries/USBPD_SINK/src/usbpd_sink.h
@@ -5,6 +5,7 @@
 extern "C" {
 #endif /* end of __cplusplus */
 
+#include <stdbool.h>
 #include "usbpd_def.h"
 
 // Register Bit Definition
@@ -201,7 +202,7 @@ void usbpd_sink_process(void);
 uint8_t usbpd_sink_get_ready(void);
 void usbpd_sink_clear_ready(void);
 
-void usbpd_sink_set_request_fixed_voltage(Request_voltage_t requestVoltage);
+bool usbpd_sink_set_request_fixed_voltage(Request_voltage_t requestVoltage);
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
As for the USB PD sink functionality, the current implementation of the `usbpd_sink_set_request_fixed_voltage` function sets the value of `pdControl_g.cc_SetPDONum` to request the voltage specified in the argument.
But the problem is that if the source side of the USB PD does not support the requested voltage, the current implementation sets the last index  (excluding the PPS) of the PDO in `pdControl_g.cc_SetPDONum`.

This is not a problem when requests the voltage supported by PD source, but means that unexpected voltage will be output when requests unsuppoted voltage by source.

For example, in the following cases:

- Supported voltages on the USB PD source: 5V, 9V, 15V, 20V
- Requested voltage to the `usbpd_sink_set_request_fixed_voltage` function: 12V (unsupported in this case)
- Actual output voltage: 20V

The return value of the `usbpd_sink_set_request_fixed_voltage` function is void, so the developer cannot determine whether the request is possible.
And also, they would not want to output the maximum voltage supported by the PD source when the specified voltage is unsupported.

Therefore, the implementation of the `usbpd_sink_set_request_fixed_voltage` function should be improved.

1. Change the return type to `bool`, and return false when an unsupported voltage is specified.
2. When an unsupported voltage is specified, do not request the wrong voltage to the USB PD source.