### PR TITLE
Print number as 0 '0' instead of empty string

### DIFF
--- a/cores/arduino/Print.cpp
+++ b/cores/arduino/Print.cpp
@@ -356,6 +356,12 @@ size_t Print::printULLNumber(unsigned long long n64, uint8_t base)
   uint8_t i = 0;
   uint8_t innerLoops = 0;
 
+  // Special case workaround https://github.com/arduino/ArduinoCore-API/issues/178
+  if (n64 == 0) {
+    write('0');
+    return 1;
+  }
+
   // prevent crash if called with base == 1
   if (base < 2) {
     base = 10;


### PR DESCRIPTION
Fixes https://github.com/openwch/arduino_core_ch32/issues/185.

Same fix as the official ArduinoAPI (https://github.com/arduino/ArduinoCore-API/pull/203).