### PR TITLE
add action to create Arduino package automatically

### DIFF
--- a/.github/workflows/packArduino.yml
+++ b/.github/workflows/packArduino.yml
@@ -1,0 +1,74 @@
+name: Pack Arduino Action
+
+on: [pull_request, push]
+
+jobs:
+    packArduino:
+        runs-on: ubuntu-latest
+
+        steps:
+        - uses: actions/checkout@v3
+
+        - name: Set release tag name for storage
+          id: tag
+          run: |
+            echo "Release tag name is arduinoPack"
+            echo "tag=arduinoPack" >> $GITHUB_ENV
+            echo "Store the github username"
+            echo "username=${{ github.actor }}" >> $GITHUB_ENV
+            echo "Store the github branch name"
+            branch_name=$(echo "${{ github.ref }}" | awk -F'/' '{print $NF}')
+            echo "branch=${branch_name}" >> $GITHUB_ENV
+
+        - name: Get current date and commit hash
+          id: vars
+          run: |
+            date=$(date +'%y.%-m.%-d')
+            commit=$(git rev-parse --short HEAD)
+            echo "Date: $date"
+            echo "Commit: $commit"
+            echo "date=$date" >> $GITHUB_ENV
+            echo "commit=$commit" >> $GITHUB_ENV
+            echo "zip_name=arduino_core_ch32_${date}_${commit}.zip" >> $GITHUB_ENV
+            echo "zip_basename=arduino_core_ch32_${date}_${commit}" >> $GITHUB_ENV
+
+        - name: Pack whole repo excluding hidden files
+          run: |
+            echo "Packing the whole repository excluding hidden files..."
+            mkdir -p ${{ env.zip_basename }}
+            shopt -s extglob
+            cp -r !(${{ env.zip_basename }}) ${{ env.zip_basename }}/
+            zip -r ${{ env.zip_name }} ${{ env.zip_basename }} -x ".*" "*~" "*.zip"
+
+        - name: Calculate SHA256 checksum
+          id: checksum
+          run: |
+            echo "Calculating SHA256 checksum..."
+            sha256sum ${{ env.zip_name }} | awk '{print $1}' > checksum.txt
+            echo "SHA256 Checksum: $(cat checksum.txt)"
+            echo "checksum=$(cat checksum.txt)" >> $GITHUB_ENV
+
+        - name: Replace content in package_ch32v_index_template.json
+          run: |
+            echo "Replacing content in package_ch32v_index_template.json, replace !!!SHA!!! with real SHA256 checksum"
+            sed -i "s/!!!SHA!!!/${{ env.checksum }}/g" package_ch32v_index_template.json
+            echo "replace !!!VERSION!!! with date_commit"
+            sed -i "s/!!!VERSION!!!/${{ env.date }}/g" package_ch32v_index_template.json
+            echo "replace !!!FILENAME!!! with real filename"
+            sed -i "s/!!!FILENAME!!!/${{ env.zip_name }}/g" package_ch32v_index_template.json
+            echo "replace !!!SIZE!!! with real size"
+            sed -i "s/!!!SIZE!!!/$(stat -c%s ${{ env.zip_name }})/g" package_ch32v_index_template.json
+            echo "replace !!!URL!!! with soemthing like https://github.com/USERNAME/arduino_core_ch32/arduino_core_ch32/releases/download/TAG/ZIPFILENAME"
+            sed -i "s/!!!URL!!!/https:\/\/github.com\/${{ env.username }}\/arduino_core_ch32\/releases\/download\/${{ env.tag }}\/${{ env.zip_name }}/g" package_ch32v_index_template.json
+            echo "copy file to package_ch32v_index_BRANCHNAME.json"
+            cp package_ch32v_index_template.json package_ch32v_index_${{ env.branch }}.json
+            echo "-----preview the file------"
+            cat package_ch32v_index_template.json
+            
+            
+        - name: Upload asset, make sure you have a release tagged arduinoPack
+          env:
+            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          run: |
+            gh release upload ${{ env.tag }} ${{ env.zip_name }} --clobber
+            gh release upload ${{ env.tag }} package_ch32v_index_${{ env.branch }}.json --clobber

--- a/package_ch32v_index_template.json
+++ b/package_ch32v_index_template.json
@@ -1,0 +1,174 @@
+{
+    "packages": [
+        {
+            "name": "WCH",
+            "websiteURL": "https://www.wch.cn/",
+            "maintainer": "WCH",
+            "email": "tech@wch.cn",
+            "help": {
+                "online": "https://www.wch.cn/"
+            },
+            "platforms": [
+                {
+                    "name": "CH32 MCU EVT Boards",
+                    "architecture": "ch32v",
+                    "version": "!!!VERSION!!!",
+                    "category": "Contributed",
+                    "url": "!!!URL!!!",
+                    "archiveFileName": "!!!FILENAME!!!",
+                    "checksum": "SHA-256:!!!SHA!!!",
+                    "size": "!!!SIZE!!!",
+                    "boards": [
+                        {
+                            "name": "CH32X035 EVT Board"
+                        },
+                        {
+                            "name": "CH32V30x EVT Board"
+                        },
+                        {
+                            "name": "CH32V20x EVT Board"
+                        },
+                        {
+                            "name": "CH32V10x EVT Board"
+                        },
+                        {
+                            "name": "CH32V00x EVT Board"
+                        }
+                    ],
+                    "toolsDependencies": [
+                        {
+                            "packager": "WCH",
+                            "name": "riscv-none-embed-gcc",
+                            "version": "8.2.0"
+                        },
+                        {
+                            "packager": "WCH",
+                            "name": "openocd",
+                            "version": "1.0.0"
+                        },
+                        {
+                            "packager": "WCH",
+                            "name": "wchisp",
+                            "version": "0.3.0"
+                        },
+                        {
+                            "packager": "WCH",
+                            "name": "beforeinstall",
+                            "version": "1.0.0"
+                        }
+                    ]
+                }
+            ],
+            "tools": [
+                {
+                    "name": "riscv-none-embed-gcc",
+                    "version": "8.2.0",
+                    "systems": [
+                        {
+                            "host": "i686-mingw32",
+                            "url": "https://github.com/DeqingSun/arduino_core_ch32/releases/download/initBinStorage/risc-none-embed-gcc-8.2.0.zip",
+                            "archiveFileName": "risc-none-embed-gcc-8.2.0.zip",
+                            "checksum": "SHA-256:43DF880A1908C873A8B6AB115568C6BEAEEC41DDADEB5202703B6AA9FDE50626",
+                            "size": "267710516"
+                        },
+                        {
+                            "host": "x86_64-linux-gnu",
+                            "url": "https://github.com/DeqingSun/arduino_core_ch32/releases/download/initBinStorage/wch_gcc_8_linux-8.2.0.tar.gz",
+                            "archiveFileName": "wch_gcc_8_linux-8.2.0.tar.gz",
+                            "checksum": "SHA-256:967FB021E5689FF79A06A71C7E54FB7FACE418D5E9B27EC64F5E56687557A282",
+                            "size": "245443061"
+                        },
+                        {
+                            "host": "x86_64-apple-darwin",
+                            "url": "https://github.com/DeqingSun/arduino_core_ch32/releases/download/initBinStorage/wch_gcc_macos-8.2.0.tar.gz",
+                            "archiveFileName": "wch_gcc_macos-8.2.0.tar.gz",
+                            "checksum": "SHA-256:E14538AE7B621DE798C2466B338A4174CCE22C9CF12E5C1684C0995931738260",
+                            "size": "160591401"
+                        }
+                    ]
+                },
+                {
+                    "name": "openocd",
+                    "version": "1.0.0",
+                    "systems": [
+                        {
+                            "host": "i686-mingw32",
+                            "url": "https://github.com/DeqingSun/arduino_core_ch32/releases/download/initBinStorage/openocd_wch-1.0.0.zip",
+                            "archiveFileName": "openocd_wch-1.0.0.zip",
+                            "checksum": "SHA-256:F1E54FD7F253CF37E7F4581088FF62DFDFDAB899B9D3182C36426F6146AE0465",
+                            "size": "9604774"
+                        },
+                        {
+                            "host": "x86_64-linux-gnu",
+                            "url": "https://github.com/DeqingSun/arduino_core_ch32/releases/download/initBinStorage/wch_openocd_linux-1.0.0.tar.gz",
+                            "archiveFileName": "wch_openocd_linux-1.0.0.tar.gz",
+                            "checksum": "SHA-256:10FA9CF5006C3495AEDCAFD1C3903FA8D75D513536432E1D61B59124442EB4C3",
+                            "size": "2097609"
+                        },
+                        {
+                            "host": "x86_64-apple-darwin",
+                            "url": "https://github.com/DeqingSun/arduino_core_ch32/releases/download/initBinStorage/wch_openocd_macos-1.0.0.tar.gz",
+                            "archiveFileName": "wch_openocd_macos-1.0.0.tar.gz",
+                            "checksum": "SHA-256:100DC6A75E302D5E3FF7548FE64351AA545353982BA22C19D43555F3A748BE0E",
+                            "size": "1995618"
+                        }
+                    ]
+                },
+                {
+                    "name": "wchisp",
+                    "version": "0.3.0",
+                    "systems": [
+                        {
+                            "host": "x86_64-linux-gnu",
+                            "url": "https://github.com/DeqingSun/arduino_core_ch32/releases/download/initBinStorage/wchisp-linux-x64.zip",
+                            "archiveFileName": "wchisp-linux-x64.zip",
+                            "checksum": "SHA-256:008def62c455a29e8e2ce99a8467d7d9d35e791b44d8622f8f16f94efe9e6c5f",
+                            "size": "902134"
+                        },
+                        {
+                            "host": "i686-mingw32",
+                            "url": "https://github.com/DeqingSun/arduino_core_ch32/releases/download/initBinStorage/wchisp-win-x64.zip",
+                            "archiveFileName": "wchisp-win-x64.zip",
+                            "checksum": "SHA-256:62924fb2de94e87805a11607cd6a275a4a615acaf4cacc5e38d432f737165313",
+                            "size": "731893"
+                        },
+                        {
+                            "host": "x86_64-apple-darwin",
+                            "url": "https://github.com/DeqingSun/arduino_core_ch32/releases/download/initBinStorage/wchisp-macos-x64.zip",
+                            "archiveFileName": "wchisp-macos-x64.zip",
+                            "checksum": "SHA-256:049a2c6af46b0c476d413d90b117e26840da769e2971db2ce10146841b5a63b2",
+                            "size": "858948"
+                        }
+                    ]
+                },
+                {
+                    "name": "beforeinstall",
+                    "version": "1.0.0",
+                    "systems": [
+                        {
+                            "host": "x86_64-linux-gnu",
+                            "url": "https://github.com/DeqingSun/arduino_core_ch32/releases/download/initBinStorage/wch_beforeinstall_linux-1.0.0.tar.gz",
+                            "archiveFileName": "wch_beforeinstall_linux-1.0.0.tar.gz",
+                            "checksum": "SHA-256:17EF3A94BC46B9EB9AB1FDECC48FCD3880EEB8FCC36E6648626320F0BF2864DC",
+                            "size": "507269"
+                        },
+                        {
+                            "host": "i686-mingw32",
+                            "url": "https://github.com/DeqingSun/arduino_core_ch32/releases/download/initBinStorage/wch_beforeinstall_empty.tar.gz",
+                            "archiveFileName": "wch_beforeinstall_empty.tar.gz",
+                            "checksum": "SHA-256:87f2e600b449220e88b20c5c867eb879b4acad177824fab65a9b3713d53246fd",
+                            "size": "186"
+                        },
+                        {
+                            "host": "x86_64-apple-darwin",
+                            "url": "https://github.com/DeqingSun/arduino_core_ch32/releases/download/initBinStorage/wch_beforeinstall_empty.tar.gz",
+                            "archiveFileName": "wch_beforeinstall_empty.tar.gz",
+                            "checksum": "SHA-256:87f2e600b449220e88b20c5c867eb879b4acad177824fab65a9b3713d53246fd",
+                            "size": "186"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This repo has been stall for quite a while and there are many PRs unmerged.

This PR adds a github action file that automatically pack the repo when commit or pull request. You only need to make sure you have a release tagged as "arduinoPack", then the github action will automatically add repo zip and json into that arduinoPack release.

I hope it will simplify the process of improving code in your own repo.

You may test it on
https://github.com/DeqingSun/arduino_core_ch32/releases/download/arduinoPack/package_ch32v_index_githubActionRelease.json

Also the windows installation error has been fixed. WCHISP packed as well.

The included WCHISP was compiled with https://github.com/DeqingSun/wchisp/tree/CH375DLL64_access . So if you are using Windows, CH375 (WCH official wchisptool) and LIBUSB both work.