### PR TITLE
Update Ch32V10x variants

### DIFF
--- a/variants/CH32V10x/CH32V103R8T6/variant_CH32V103R8T6.cpp
+++ b/variants/CH32V10x/CH32V103R8T6/variant_CH32V103R8T6.cpp
@@ -1,5 +1,5 @@
 /**
- *******************************************************************************
+*******************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
  * All rights reserved.
  *
@@ -22,25 +22,59 @@ const PinName digitalPin[] = {
   PA_1,  //D1/A1
   PA_2,  //D2/A2
   PA_3,  //D3/A3
-  PA_4,  //D4/A4   
-  PA_5,  //D5/A5    
+  PA_4,  //D4/A4
+  PA_5,  //D5/A5
 
-  PA_10,  //D6      USART1_RX
+  PA_6,
+  PA_7,
+  PA_8,   //D13
   PA_9,   //D7      USART1_TX
-  PB_4,   //D8   
-  PB_6,   //D9       
-  PB_7,   //D10       
-  PB_8,   //D11                 
-  PB_9,   //D12                 
-  PA_8,   //D13                  
-  PB_1,   //D14                    
-  PB_0,   //D15                     
+  PA_10,  //D6      USART1_RX
+  PA_11,
+  PA_12,
+  PA_13,
+  PA_14,
+  PA_15,
+
+  PB_0,   //D15
+  PB_1,   //D14
+  PB_2,
+  PB_3
+  PB_4,   //D8
+  PB_5,
+  PB_6,   //D9
+  PB_7,   //D10
+  PB_8,   //D11
+  PB_9,   //D12
+  PB_10,  //D21    I2C2_SCL USART3_TX
+  PB_11,  //D20    I2C2_SDA USART3_RX
   PB_12,  //D16    SPI2_NSS
-  PB_15,  //D17    SPI2_MOSI  
-  PB_14,  //D18    SPI2_MISO
   PB_13,  //D19    SPI2_SCK
-  PB_11,  //D20    I2C2_SDA
-  PB_10   //D21    I2C2_SCL
+  PB_14,  //D18    SPI2_MISO
+  PB_15,  //D17    SPI2_MOSI
+
+
+  PC_0,
+  PC_1,
+  PC_2,
+  PC_3,
+  PC_4,
+  PC_5,
+  PC_6,
+  PC_7,
+  PC_8,
+  PC_9,
+  PC_10,
+  PC_11,
+  PC_12,
+  PC_13,
+  PC_14,
+  PC_15,
+
+  PD_0,
+  PD_1,
+  PD_2
+
 };
 
 // Analog (Ax) pin number array

--- a/variants/CH32V10x/CH32V103R8T6/variant_CH32V103R8T6.cpp
+++ b/variants/CH32V10x/CH32V103R8T6/variant_CH32V103R8T6.cpp
@@ -39,7 +39,7 @@ const PinName digitalPin[] = {
   PB_0,   //D15
   PB_1,   //D14
   PB_2,
-  PB_3
+  PB_3,
   PB_4,   //D8
   PB_5,
   PB_6,   //D9

--- a/variants/CH32V10x/CH32V103R8T6/variant_CH32V103R8T6.cpp
+++ b/variants/CH32V10x/CH32V103R8T6/variant_CH32V103R8T6.cpp
@@ -1,5 +1,5 @@
 /**
- *******************************************************************************
+*******************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
  * All rights reserved.
  *
@@ -22,25 +22,59 @@ const PinName digitalPin[] = {
   PA_1,  //D1/A1
   PA_2,  //D2/A2
   PA_3,  //D3/A3
-  PA_4,  //D4/A4   
-  PA_5,  //D5/A5    
+  PA_4,  //D4/A4
+  PA_5,  //D5/A5
 
-  PA_10,  //D6      USART1_RX
+  PA_6,
+  PA_7,
+  PA_8,   //D13
   PA_9,   //D7      USART1_TX
-  PB_4,   //D8   
-  PB_6,   //D9       
-  PB_7,   //D10       
-  PB_8,   //D11                 
-  PB_9,   //D12                 
-  PA_8,   //D13                  
-  PB_1,   //D14                    
-  PB_0,   //D15                     
+  PA_10,  //D6      USART1_RX
+  PA_11,
+  PA_12,
+  PA_13,
+  PA_14,
+  PA_15,
+
+  PB_0,   //D15
+  PB_1,   //D14
+  PB_2,
+  PB_3,
+  PB_4,   //D8
+  PB_5,
+  PB_6,   //D9
+  PB_7,   //D10
+  PB_8,   //D11
+  PB_9,   //D12
+  PB_10,  //D21    I2C2_SCL USART3_TX
+  PB_11,  //D20    I2C2_SDA USART3_RX
   PB_12,  //D16    SPI2_NSS
-  PB_15,  //D17    SPI2_MOSI  
-  PB_14,  //D18    SPI2_MISO
   PB_13,  //D19    SPI2_SCK
-  PB_11,  //D20    I2C2_SDA
-  PB_10   //D21    I2C2_SCL
+  PB_14,  //D18    SPI2_MISO
+  PB_15,  //D17    SPI2_MOSI
+
+
+  PC_0,
+  PC_1,
+  PC_2,
+  PC_3,
+  PC_4,
+  PC_5,
+  PC_6,
+  PC_7,
+  PC_8,
+  PC_9,
+  PC_10,
+  PC_11,
+  PC_12,
+  PC_13,
+  PC_14,
+  PC_15,
+
+  PD_0,
+  PD_1,
+  PD_2
+
 };
 
 // Analog (Ax) pin number array

--- a/variants/CH32V10x/CH32V103R8T6/variant_CH32V103R8T6.h
+++ b/variants/CH32V10x/CH32V103R8T6/variant_CH32V103R8T6.h
@@ -15,39 +15,68 @@
 /* ENABLE Peripherals */
 #define                         ADC_MODULE_ENABLED
 #define                         UART_MODULE_ENABLED
-#define                         SPI_MODULE_ENABLED  
+#define                         SPI_MODULE_ENABLED
 #define                         I2C_MODULE_ENABLED
 #define                         TIM_MODULE_ENABLED
 
-/* CH32V307VCT6 Pins */
+/* CH32V103R8T6 Pins */
 
-#define PA0                     PIN_A0
-#define PA1                     PIN_A1
-#define PA2                     PIN_A2
-#define PA3                     PIN_A3
-#define PA4                     PIN_A4
-#define PA5                     PIN_A5
+#define PA0                     0   // D0/A0
+#define PA1                     1   // D1/A1
+#define PA2                     2   // D2/A2
+#define PA3                     3   // D3/A3
+#define PA4                     4   // D4/A4
+#define PA5                     5   // D5/A5
+#define PA6                     6
+#define PA7                     7
+#define PA8                     8
+#define PA9                     9   // USART1_TX
+#define PA10                    10  // USART1_RX
+#define PA11                    11
+#define PA12                    12
+#define PA13                    13
+#define PA14                    14
+#define PA15                    15
+#define PB0                     16
+#define PB1                     17
+#define PB2                     18
+#define PB3                     19
+#define PB4                     20
+#define PB5                     21
+#define PB6                     22
+#define PB7                     23
+#define PB8                     24
+#define PB9                     25
+#define PB10                    26  // I2C2_SCL USART3_TX
+#define PB11                    27  // I2C2_SDA USART3_RX
+#define PB12                    28  // SPI2_NSS
+#define PB13                    29  // SPI2_SCK
+#define PB14                    30  // SPI2_MISO
+#define PB15                    31  // SPI2_MOSI
+#define PC0                     32
+#define PC1                     33
+#define PC2                     34
+#define PC3                     35
+#define PC4                     36
+#define PC5                     37
+#define PC6                     38
+#define PC7                     39
+#define PC8                     40
+#define PC9                     41
+#define PC10                    42
+#define PC11                    43
+#define PC12                    44
+#define PC13                    45
+#define PC14                    46
+#define PC15                    47
+#define PD0                     48
+#define PD1                     49
+#define PD2                     50
 
-#define PA10                    6
-#define PA9                     7
-#define PA8                     8                     
-#define PA7                     9
-#define PA6                     10
-#define PB5                     11 
-#define PB8                     12
-#define PB9                     13
-#define PB1                     14
-#define PB0                     15
-#define PB12                    16
-#define PB15                    17       
-#define PB14                    18
-#define PB13                    19
-#define PB11                    20
-#define PB10                    21 
 
 
 // Alternate pins number
-#define PA0_ALT1                (PA0  | ALT1) 
+#define PA0_ALT1                (PA0  | ALT1)
 #define PA1_ALT1                (PA1  | ALT1)
 #define PA2_ALT1                (PA2  | ALT1)
 #define PA3_ALT1                (PA3  | ALT1)
@@ -59,9 +88,9 @@
 
 
 
-#define NUM_DIGITAL_PINS        22
+#define NUM_DIGITAL_PINS        51
 #define NUM_ANALOG_INPUTS       6
-// #define ADC_CTLR_ADCAL          
+// #define ADC_CTLR_ADCAL
 #define ADC_RESOLUTION          12
 
 


### PR DESCRIPTION
Fix #210 
Fully updated the pin definitions of CH32V103R8T6 according to the manual.
![image](https://github.com/user-attachments/assets/721aa0c6-fa9f-4269-96fb-866d89257312)
