### PR TITLE
Fix for using LTO in Arduino IDE 2.x to reduce flash usage

### DIFF
--- a/system/CH32V00x/SRC/Peripheral/src/ch32v00x_misc.c
+++ b/system/CH32V00x/SRC/Peripheral/src/ch32v00x_misc.c
@@ -107,3 +107,31 @@ void NVIC_Init(NVIC_InitTypeDef *NVIC_InitStruct)
         NVIC_DisableIRQ(NVIC_InitStruct->NVIC_IRQChannel);
     }
 }
+
+
+/* MMOLE 250727: moved from startup_ch32v00x.S to ch32v00x_misc.c (see issue #204) */
+__attribute__ ((weak)) void while1_handler(void) {while(1);};
+__attribute__ ((weak)) void SW_Handler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void WWDG_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void PVD_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void FLASH_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void RCC_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void EXTI7_0_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void AWU_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void DMA1_Channel1_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void DMA1_Channel2_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void DMA1_Channel3_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void DMA1_Channel4_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void DMA1_Channel5_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void DMA1_Channel6_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void DMA1_Channel7_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void ADC1_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void I2C1_EV_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void I2C1_ER_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void USART1_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void SPI1_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void TIM1_BRK_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void TIM1_UP_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void TIM1_TRG_COM_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void TIM1_CC_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void TIM2_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));

--- a/system/CH32V00x/SRC/Startup/startup_ch32v00x.S
+++ b/system/CH32V00x/SRC/Startup/startup_ch32v00x.S
@@ -56,6 +56,8 @@ _start:
     .word   TIM1_CC_IRQHandler         	/* TIM1 Capture Compare */
     .word   TIM2_IRQHandler            	/* TIM2 */
 
+/* MMOLE 250727: moved from startup_ch32v00x.S to ch32v00x_misc.c (see issue #204)
+
 	.option rvc;
 	.section  .text.vector_handler, "ax", @progbits
 	.weak   NMI_Handler
@@ -114,6 +116,7 @@ TIM1_TRG_COM_IRQHandler:  1: j 1b
 TIM1_CC_IRQHandler:       1: j 1b
 TIM2_IRQHandler:          1: j 1b
 
+*/
 
 	.section  .text.handle_reset, "ax", @progbits
 	.weak     handle_reset

--- a/system/CH32VM00X/SRC/Peripheral/src/ch32v00X_misc.c
+++ b/system/CH32VM00X/SRC/Peripheral/src/ch32v00X_misc.c
@@ -79,3 +79,39 @@ void NVIC_Init(NVIC_InitTypeDef *NVIC_InitStruct)
         NVIC_DisableIRQ(NVIC_InitStruct->NVIC_IRQChannel);
     }
 }
+
+
+/* MMOLE 250727: moved from startup_ch32v00X.S to ch32v00X_misc.c (see issue #204) */
+__attribute__ ((weak)) void while1_handler(void) {while(1);};
+__attribute__ ((weak)) void SW_Handler (void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void WWDG_IRQHandler (void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void PVD_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void FLASH_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void RCC_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void EXTI7_0_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void AWU_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void DMA1_Channel1_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void DMA1_Channel2_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void DMA1_Channel3_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void DMA1_Channel4_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void DMA1_Channel5_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void DMA1_Channel6_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void DMA1_Channel7_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void ADC1_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void I2C1_EV_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void I2C1_ER_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void USART1_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void SPI1_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void TIM1_BRK_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void TIM1_UP_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void TIM1_TRG_COM_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void TIM1_CC_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void TIM2_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void USART2_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void OPCM_IRQHandler(void) __attribute__ ((weak, alias ("while1_handler")));
+
+/*
+	.weak   NMI_Handler
+	.weak   HardFault_Handler
+	.weak   SysTick_Handler
+*/

--- a/system/CH32VM00X/SRC/Startup/startup_ch32v00X.S
+++ b/system/CH32VM00X/SRC/Startup/startup_ch32v00X.S
@@ -58,6 +58,7 @@ _start:
     .word   USART2_IRQHandler          	/* USART2 */
     .word   OPCM_IRQHandler            	/* OPCM */
 
+/* MMOLE 250727: moved from startup_ch32v00X.S to ch32v00X_misc.c (see issue #204)
 	.option rvc;
 	.section  .text.vector_handler, "ax", @progbits
 	.weak   NMI_Handler
@@ -121,6 +122,8 @@ USART2_IRQHandler:
 OPCM_IRQHandler:
 1:
 	j 1b
+  
+*/
 
 	.section  .text.handle_reset, "ax", @progbits
 	.weak     handle_reset

--- a/system/CH32X035/SRC/Peripheral/src/ch32x035_misc.c
+++ b/system/CH32X035/SRC/Peripheral/src/ch32x035_misc.c
@@ -107,3 +107,54 @@ void NVIC_Init(NVIC_InitTypeDef *NVIC_InitStruct)
         NVIC_DisableIRQ(NVIC_InitStruct->NVIC_IRQChannel);
     }
 }
+
+/* MMOLE 250805: moved from startup_ch32x035.S to ch32x035_misc.c (see issue #204) */
+__attribute__ ((weak)) void while1_handler(void) {while(1);};
+__attribute__ ((weak)) void Ecall_M_Mode_Handler (void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void Ecall_U_Mode_Handler (void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void Break_Point_Handler (void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void SW_Handler (void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void WWDG_IRQHandler (void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void PVD_IRQHandler (void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void FLASH_IRQHandler (void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void EXTI7_0_IRQHandler (void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void AWU_IRQHandler (void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void DMA1_Channel1_IRQHandler (void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void DMA1_Channel2_IRQHandler (void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void DMA1_Channel3_IRQHandler (void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void DMA1_Channel4_IRQHandler (void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void DMA1_Channel5_IRQHandler (void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void DMA1_Channel6_IRQHandler (void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void DMA1_Channel7_IRQHandler (void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void ADC1_IRQHandler (void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void I2C1_EV_IRQHandler (void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void I2C1_ER_IRQHandler (void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void USART1_IRQHandler (void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void SPI1_IRQHandler (void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void TIM1_BRK_IRQHandler (void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void TIM1_UP_IRQHandler (void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void TIM1_TRG_COM_IRQHandler (void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void TIM1_CC_IRQHandler (void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void TIM2_UP_IRQHandler (void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void USART2_IRQHandler (void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void EXTI15_8_IRQHandler (void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void EXTI25_16_IRQHandler (void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void USART3_IRQHandler (void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void USART4_IRQHandler (void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void DMA1_Channel8_IRQHandler (void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void USBFS_IRQHandler (void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void USBFSWakeUp_IRQHandler (void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void PIOC_IRQHandler (void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void OPA_IRQHandler (void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void USBPD_IRQHandler (void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void USBPDWakeUp_IRQHandler (void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void TIM2_CC_IRQHandler (void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void TIM2_TRG_COM_IRQHandler (void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void TIM2_BRK_IRQHandler (void) __attribute__ ((weak, alias ("while1_handler")));
+__attribute__ ((weak)) void TIM3_IRQHandler (void) __attribute__ ((weak, alias ("while1_handler")));
+
+/*
+NMI_Handler:  1:  j 1b
+HardFault_Handler:  1:  j 1b
+SysTick_Handler:  1:  j 1b
+*/

--- a/system/CH32X035/SRC/Startup/startup_ch32x035.S
+++ b/system/CH32X035/SRC/Startup/startup_ch32x035.S
@@ -76,54 +76,55 @@ _vector_base:
     .word   TIM2_BRK_IRQHandler        /* TIM2 Break */
     .word   TIM3_IRQHandler            /* TIM3 */
 
+/* MMOLE 250805: moved from startup_ch32x035.S to ch32x035_misc.c (see issue #204)
     .option rvc;
 
     .section    .text.vector_handler, "ax", @progbits
-    .weak   NMI_Handler                /* NMI */
-    .weak   HardFault_Handler          /* Hard Fault */
-    .weak   Ecall_M_Mode_Handler       /* Ecall M Mode */
-    .weak   Ecall_U_Mode_Handler       /* Ecall U Mode */
-    .weak   Break_Point_Handler        /* Break Point */
-    .weak   SysTick_Handler            /* SysTick */
-    .weak   SW_Handler                 /* SW */
-    .weak   WWDG_IRQHandler            /* Window Watchdog */
-    .weak   PVD_IRQHandler             /* PVD through EXTI Line detect */
-    .weak   FLASH_IRQHandler           /* Flash */
-    .weak   EXTI7_0_IRQHandler         /* EXTI Line 7..0 */
-    .weak   AWU_IRQHandler             /* Auto Wake up */
-    .weak   DMA1_Channel1_IRQHandler   /* DMA1 Channel 1 */
-    .weak   DMA1_Channel2_IRQHandler   /* DMA1 Channel 2 */
-    .weak   DMA1_Channel3_IRQHandler   /* DMA1 Channel 3 */
-    .weak   DMA1_Channel4_IRQHandler   /* DMA1 Channel 4 */
-    .weak   DMA1_Channel5_IRQHandler   /* DMA1 Channel 5 */
-    .weak   DMA1_Channel6_IRQHandler   /* DMA1 Channel 6 */
-    .weak   DMA1_Channel7_IRQHandler   /* DMA1 Channel 7 */
-    .weak   ADC1_IRQHandler            /* ADC1 */
-    .weak   I2C1_EV_IRQHandler         /* I2C1 Event */
-    .weak   I2C1_ER_IRQHandler         /* I2C1 Error */
-    .weak   USART1_IRQHandler          /* USART1 */
-    .weak   SPI1_IRQHandler            /* SPI1 */
-    .weak   TIM1_BRK_IRQHandler        /* TIM1 Break */
-    .weak   TIM1_UP_IRQHandler         /* TIM1 Update */
-    .weak   TIM1_TRG_COM_IRQHandler    /* TIM1 Trigger and Commutation */
-    .weak   TIM1_CC_IRQHandler         /* TIM1 Capture Compare */
-    .weak   TIM2_UP_IRQHandler         /* TIM2 Update */
-    .weak   USART2_IRQHandler          /* USART2 */
-    .weak   EXTI15_8_IRQHandler        /* EXTI Line 15..8 */
-    .weak   EXTI25_16_IRQHandler       /* EXTI Line 25..16 */
-    .weak   USART3_IRQHandler          /* USART3 */
-    .weak   USART4_IRQHandler          /* USART4 */
-    .weak   DMA1_Channel8_IRQHandler   /* DMA1 Channel8 */
-    .weak   USBFS_IRQHandler           /* USBFS Break */
-    .weak   USBFSWakeUp_IRQHandler     /* USBFS Wake up from suspend */
-    .weak   PIOC_IRQHandler            /* PIOC */
-    .weak   OPA_IRQHandler             /* OPA */
-    .weak   USBPD_IRQHandler           /* USBPD */
-    .weak   USBPDWakeUp_IRQHandler     /* USBPD Wake up */
-    .weak   TIM2_CC_IRQHandler         /* TIM2 Capture Compare */
-    .weak   TIM2_TRG_COM_IRQHandler    /* TIM2 Trigger and Commutation */
-    .weak   TIM2_BRK_IRQHandler        /* TIM2 Break */
-    .weak   TIM3_IRQHandler            /* TIM3 */
+    .weak   NMI_Handler
+    .weak   HardFault_Handler
+    .weak   Ecall_M_Mode_Handler
+    .weak   Ecall_U_Mode_Handler
+    .weak   Break_Point_Handler
+    .weak   SysTick_Handler
+    .weak   SW_Handler
+    .weak   WWDG_IRQHandler
+    .weak   PVD_IRQHandler
+    .weak   FLASH_IRQHandler
+    .weak   EXTI7_0_IRQHandler
+    .weak   AWU_IRQHandler
+    .weak   DMA1_Channel1_IRQHandler
+    .weak   DMA1_Channel2_IRQHandler
+    .weak   DMA1_Channel3_IRQHandler
+    .weak   DMA1_Channel4_IRQHandler
+    .weak   DMA1_Channel5_IRQHandler
+    .weak   DMA1_Channel6_IRQHandler
+    .weak   DMA1_Channel7_IRQHandler
+    .weak   ADC1_IRQHandler
+    .weak   I2C1_EV_IRQHandler
+    .weak   I2C1_ER_IRQHandler
+    .weak   USART1_IRQHandler
+    .weak   SPI1_IRQHandler
+    .weak   TIM1_BRK_IRQHandler
+    .weak   TIM1_UP_IRQHandler
+    .weak   TIM1_TRG_COM_IRQHandler
+    .weak   TIM1_CC_IRQHandler
+    .weak   TIM2_UP_IRQHandler
+    .weak   USART2_IRQHandler
+    .weak   EXTI15_8_IRQHandler
+    .weak   EXTI25_16_IRQHandler
+    .weak   USART3_IRQHandler
+    .weak   USART4_IRQHandler
+    .weak   DMA1_Channel8_IRQHandler
+    .weak   USBFS_IRQHandler
+    .weak   USBFSWakeUp_IRQHandler
+    .weak   PIOC_IRQHandler
+    .weak   OPA_IRQHandler
+    .weak   USBPD_IRQHandler
+    .weak   USBPDWakeUp_IRQHandler
+    .weak   TIM2_CC_IRQHandler
+    .weak   TIM2_TRG_COM_IRQHandler
+    .weak   TIM2_BRK_IRQHandler
+    .weak   TIM3_IRQHandler
 
 NMI_Handler:  1:  j 1b
 HardFault_Handler:  1:  j 1b
@@ -170,6 +171,7 @@ TIM2_CC_IRQHandler:  1:  j 1b
 TIM2_TRG_COM_IRQHandler:  1:  j 1b
 TIM2_BRK_IRQHandler:  1:  j 1b
 TIM3_IRQHandler:  1:  j 1b
+*/
 
 	.section	.text.handle_reset,"ax",@progbits
 	.weak	handle_reset


### PR DESCRIPTION
Fix #204, fix #179, fix #25. 
First only for CH32V003, CH32VM00X, other may follow...

Flash memory fills up quickly, especially on chips like the V003 and V002 that have only 16kB of flash. 

As mentioned in [this comment](https://github.com/openwch/arduino_core_ch32/issues/179#issuecomment-2650178262), one of the ways to reduce flash usage, is to use Link Time Optimization (LTO). LTO removes code that is never called; potentially saving multiple kilobytes of valuable flash memory. This optimization worked great in version 1.8.19 of the Arduino IDE, but didn't work in any v2.x IDE (see also [another comment](https://github.com/openwch/arduino_core_ch32/issues/25#issuecomment-2021527823)). Note that LTO can also reduce RAM usage.

After lengthy research (see #204) the main cause appeared to be a [known issue](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=83967) in the used GCC compiler/linker, related to how weak functions defined in assembly files can take precedence over regular functions that were supposed to redefine their weak counterparts. 

For the CH32 Arduino core this issue caused important interrupt handlers such as the SysTick handler to be removed when using LTO, leaving the microcontroller hanging in the endless loop of the default handler when such an interrupt occurred.

So far the best workaround found to get LTO working again, was to move the assembly implementation of the default handlers from [`startup_ch32....S`](https://github.com/openwch/arduino_core_ch32/blob/main/system/CH32V00x/SRC/Startup/startup_ch32v00x.S) to a C implementation in [`ch32...._misc.c`](https://github.com/openwch/arduino_core_ch32/blob/main/system/CH32V00x/SRC/Peripheral/src/ch32v00x_misc.c). Note: both assembly and C implementations use just two bytes of flash. For the CH32V003 the code is somewhat smaller than before (even without LTO!). Thanks @dfleck for contributing this solution.

This PR gives priority to fixing LTO on 16kB processors (mainly V003/V002). Others may follow later. Although the fix is fairly straightforward, I prefer to only submit tested changes and don't have all member of the CH32 family in my collection.

See #204 for more information. 
Related issues: #179, #25, 