### PR TITLE
Enable timer preload function to prevent output glitches

### DIFF
--- a/cores/arduino/HardwareTimer.cpp
+++ b/cores/arduino/HardwareTimer.cpp
@@ -783,7 +783,14 @@ void HardwareTimer::setMode(uint32_t channel, TimerModes_t mode, PinName pin)
 
   /* Configure some default values. Maybe overwritten later */
   channelOC.TIM_OCMode = TIMER_NOT_USED;  //set default value 0xFFFF
-
+  
+  // Enable preload (shadow registers) for timer channel to prevent output glitches
+  // Ensures compare register updates only take effect at timer overflow/update events
+  TIM_OC1PreloadConfig(_timerObj.handle.Instance, TIM_OCPreload_Enable); 
+  TIM_OC2PreloadConfig(_timerObj.handle.Instance, TIM_OCPreload_Enable);
+  TIM_OC3PreloadConfig(_timerObj.handle.Instance, TIM_OCPreload_Enable);
+  TIM_OC4PreloadConfig(_timerObj.handle.Instance, TIM_OCPreload_Enable);
+  
   // channelOC.Pulse = __HAL_TIM_GET_COMPARE(&(_timerObj.handle), timChannel);  // keep same value already written in hardware register
   channelOC.TIM_Pulse =  (((timChannel) == TIM_Channel_1) ? (_timerObj.handle.Instance->CH1CVR) :\
                           ((timChannel) == TIM_Channel_2) ? (_timerObj.handle.Instance->CH2CVR) :\


### PR DESCRIPTION
## Problem
`analogWrite()` on CH32V003 produces occasional glitches when updating the PWM duty cycle. Changes take effect mid-cycle, rather than at cycle boundaries.

## Solution
Enable timer preload registers (shadow registers) for PWM channels to synchronize compare value updates with timer overflow events.

## Changes
- Enable `TIM_OCPreload_Enable` for timer channels in PWM mode
- Ensures duty cycle updates only take effect at start of next PWM cycle
- Prevents mid-cycle glitches during `analogWrite()` calls

**Fixes**: #223