### PR TITLE
Hsck for working analogRead for internal channels (Vref and Temperature)

### DIFF
--- a/cores/arduino/ch32/analog.cpp
+++ b/cores/arduino/ch32/analog.cpp
@@ -628,6 +628,10 @@ uint16_t adc_read_value(PinName pin, uint32_t resolution)
     channel = get_adc_internal_channel(pin);
     samplingTime = ADC_SAMPLINGTIME_INTERNAL;
     padc = ADC1;
+    #if defined(CH32V20x) 
+     ADC_TempSensorVrefintCmd(ENABLE);         /* enable internal channels, not sure about other platforms... */
+    #endif 
+
   } 
   else 
   {

--- a/cores/arduino/wiring_analog.c
+++ b/cores/arduino/wiring_analog.c
@@ -125,6 +125,11 @@ uint32_t analogRead(uint32_t ulPin)
   uint32_t value = 0;
 #if defined(ADC_MODULE_ENABLED) && !defined(ADC_MODULE_ONLY)
   PinName p = analogInputToPinName(ulPin);
+ if ((ulPin & PADC_BASE) && (ulPin < ANA_START))  //internal channel 
+  {
+    p = ulPin;  // replace back internal channel reference
+  } 
+
   if (p != NC) {
     value = adc_read_value(p, _internalReadResolution);
     value = mapResolution(value, _internalReadResolution, _readResolution);


### PR DESCRIPTION
This is small hack to get working analogRead for internal channels (Vref and Temperature). It is not nice, but works.
It cover 2 defects: 1) enable power for devices, when they are used (limited to CH32V20x, have no knowledge about others); 2) update of Input Pin To Name, to preserve internal channels (PADC_VREF, PADC_TEMP, ...);