### PR TITLE
fix micros() is non-monotonic

### DIFF
--- a/cores/arduino/ch32/clock.c
+++ b/cores/arduino/ch32/clock.c
@@ -61,9 +61,9 @@ uint32_t getCurrentMicros(void)
    uint64_t tms = SysTick->CMP + 1;
 
   if (m1 != m0) {
-    return (m1 * 1000 + ((tms - u1) * 1000) / tms);
+    return m1 * 1000 + u1 * 1000 / tms;  // fix #65 - micros() is non-monotonic 
   } else {
-    return (m0 * 1000 + ((tms - u0) * 1000) / tms);
+    return m0 * 1000 + u0 * 1000 / tms;  // fix #65 - micros() is non-monotonic 
   }
 }
 
@@ -112,9 +112,9 @@ uint32_t getCurrentMicros(void)
            tms = (tms << 32) + *((__IO uint32_t *)SYSTICK_CMPL) + 1;     
 
   if (m1 != m0) {
-    return (m1 * 1000 + ((tms - u1) * 1000) / tms);
+    return m1 * 1000 + u1 * 1000 / tms;  // fix #65 - micros() is non-monotonic 
   } else {
-    return (m0 * 1000 + ((tms - u0) * 1000) / tms);
+    return m0 * 1000 + u0 * 1000 / tms;  // fix #65 - micros() is non-monotonic 
   }
 }
 


### PR DESCRIPTION
Fixes #65 - micros() is non-monotonic
------------
I saw that the current master branch didn't include the fix for issues with micros() yes. For a detailed description of the issue and the proposed solution please read #65.

**Background**
Yesterday I was working on CH570 and tested a CH32V203 with my TM16xx LED display library. The TM1652 has a single dataline that relies on having a fairly precise bit duration. It uses `delayMicrosenconds()` and `micros()` to achieve that. To fix a 32-bit roll-over issue, spend duration was calculated by subtracting start time from `micros()`. This didn't work. After an hour of debugging I found that the fresh installment of the CH32 core didn't have this fix yet. For that reason a separate PR seems useful.

